### PR TITLE
issue 1554

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1415,6 +1415,7 @@ public class DeckPicker extends FragmentActivity {
                                         if (mProgressDialog.isShowing()) {
                                             try {
                                                 mProgressDialog.dismiss();
+                                                removeDialog(DIALOG_DELETE_DECK);
                                             } catch (Exception e) {
                                                 Log.e(AnkiDroidApp.TAG, "onPostExecute - Dialog dismiss Exception = "
                                                         + e.getMessage());


### PR DESCRIPTION
First deck name is shown twice when deleting two decks. Fixed by
removing dialog after it is closed instead of just dismiss.
