### PR TITLE
Insert class attribute for card-specific styling

### DIFF
--- a/assets/card_template.html
+++ b/assets/card_template.html
@@ -53,7 +53,7 @@
 		<style>::style::</style>
 	</head> 
 	<body class="mobile"> 
-		<span class="card">::content::</span>
+		<span class="::class::">::content::</span>
 		<script type="text/javascript">
 			init();
 			window.location.href = "#question"

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2456,6 +2456,9 @@ public class Reviewer extends AnkiActivity {
             // font-weight to 700
             content = content.replace("font-weight:600;", "font-weight:700;");
 
+            // CSS class for card-specific styling
+            String cardClass = "card card" + (mCurrentCard.getOrd()+1);
+            
             // Log.i(AnkiDroidApp.TAG, "content card = \n" + content);
             StringBuilder style = new StringBuilder();
             style.append(mCustomFontStyle);
@@ -2467,7 +2470,7 @@ public class Reviewer extends AnkiActivity {
 
             content = SmpToHtmlEntity(content);
             mCardContent = new SpannedString(mCardTemplate.replace("::content::", content).replace("::style::",
-                    style.toString()));
+                    style.toString()).replace("::class::", cardClass));
             // Log.i(AnkiDroidApp.TAG, "base url = " + mBaseUrl);
 
             fillFlashcard(mShowAnimations);


### PR DESCRIPTION
This will support the ability to apply CSS rules to specific cards, in line with the desktop application. So you can now do something like:

```
.card1 {font-size: 20px;}
.card2 {font-size: 40px;}
```

I found three issues in the tracker for it.

[Issue 1246](http://code.google.com/p/ankidroid/issues/detail?id=1246)
[Issue 1568](http://code.google.com/p/ankidroid/issues/detail?id=1568)
[Issue 1530](http://code.google.com/p/ankidroid/issues/detail?id=1530)
