### PR TITLE
V2.0.1 setmod at fullsync

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1492,9 +1492,9 @@ public class DeckPicker extends FragmentActivity {
                 break;
 
             case DIALOG_SYNC_SANITY_ERROR:
-                builder.setPositiveButton(res.getString(R.string.sync_conflict_local), mSyncConflictResolutionListener);
-                builder.setNeutralButton(res.getString(R.string.sync_conflict_remote), mSyncConflictResolutionListener);
-                builder.setNegativeButton(res.getString(R.string.sync_conflict_cancel), mSyncConflictResolutionListener);
+                builder.setPositiveButton(res.getString(R.string.sync_conflict_local), mSyncSanityFailListener);
+                builder.setNeutralButton(res.getString(R.string.sync_conflict_remote), mSyncSanityFailListener);
+                builder.setNegativeButton(res.getString(R.string.sync_conflict_cancel), mSyncSanityFailListener);
                 builder.setTitle(res.getString(R.string.sync_log_title));
                 dialog = builder.create();
                 break;
@@ -2139,7 +2139,7 @@ public class DeckPicker extends FragmentActivity {
         }
     }
 
-    private DialogInterface.OnClickListener mSyncConflictResolutionListener = new DialogInterface.OnClickListener() {
+    private DialogInterface.OnClickListener mSyncSanityFailListener = new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialog, int which) {
             Resources res = getResources();
@@ -2150,8 +2150,13 @@ public class DeckPicker extends FragmentActivity {
                     builder.setPositiveButton(res.getString(R.string.yes), new Dialog.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
-		                    sync("upload", mSyncMediaUsn);
-						}                    	
+                            Collection col = AnkiDroidApp.getCol();
+                            if (col != null) {
+                                col.modSchema(true);
+                                col.setMod();
+                                sync("upload", 0);
+                            }
+						}
                     });
                     builder.setNegativeButton(res.getString(R.string.no), null);
                     builder.setTitle(res.getString(R.string.sync_log_title));
@@ -2163,8 +2168,13 @@ public class DeckPicker extends FragmentActivity {
                     builder.setPositiveButton(res.getString(R.string.yes), new Dialog.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
-		                    sync("download", mSyncMediaUsn);
-						}                    	
+                            Collection col = AnkiDroidApp.getCol();
+                            if (col != null) {
+                                col.modSchema(true);
+                                col.setMod();
+                                sync("download", 0);
+                            }
+						}
                     });
                     builder.setNegativeButton(res.getString(R.string.no), null);
                     builder.setTitle(res.getString(R.string.sync_log_title));
@@ -2177,6 +2187,43 @@ public class DeckPicker extends FragmentActivity {
         }
     };
 
+    private DialogInterface.OnClickListener mSyncConflictResolutionListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            Resources res = getResources();
+            StyledDialog.Builder builder;
+            switch (which) {
+                case DialogInterface.BUTTON_POSITIVE:
+                    builder = new StyledDialog.Builder(DeckPicker.this);
+                    builder.setPositiveButton(res.getString(R.string.yes), new Dialog.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            sync("upload", mSyncMediaUsn);
+                        }
+                    });
+                    builder.setNegativeButton(res.getString(R.string.no), null);
+                    builder.setTitle(res.getString(R.string.sync_log_title));
+                    builder.setMessage(res.getString(R.string.sync_conflict_local_confirm));
+                    builder.show();
+                    break;
+                case DialogInterface.BUTTON_NEUTRAL:
+                    builder = new StyledDialog.Builder(DeckPicker.this);
+                    builder.setPositiveButton(res.getString(R.string.yes), new Dialog.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            sync("download", mSyncMediaUsn);
+                        }
+                    });
+                    builder.setNegativeButton(res.getString(R.string.no), null);
+                    builder.setTitle(res.getString(R.string.sync_log_title));
+                    builder.setMessage(res.getString(R.string.sync_conflict_remote_confirm));
+                    builder.show();
+                    break;
+                case DialogInterface.BUTTON_NEGATIVE:
+                default:
+            }
+        }
+    };
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {

--- a/src/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/src/com/ichi2/libanki/sync/MediaSyncer.java
@@ -88,8 +88,8 @@ public class MediaSyncer {
             }
             long usn = mServer.addFiles(zipAdded.first);
             if (usn == 0) {
-            	// an error occurred, return
-            	return null;
+                // an error occurred, return
+                return null;
             }
             // after server has replied, safe to remove from log
             zipAdded.first.delete(); // remove the temporary file created by Media.zipAdded
@@ -105,7 +105,7 @@ public class MediaSyncer {
         if (cMediaSanity.first != 0 || sMediaSanity != cMediaSanity.second) {
             Log.e(AnkiDroidApp.TAG,
                     "Media sanity check failed. Diffs [local, server] - Logs: [" + cMediaSanity.first +
-                    ", 0], Counts: [" + cMediaSanity.second + ", " + sMediaSanity + "]");
+                            ", 0], Counts: [" + cMediaSanity.second + ", " + sMediaSanity + "]");
             if (cMediaSanity.first != 0) {
                 AnkiDroidApp.saveExceptionReportFile(new RuntimeException(
                         "Media sanity check failed. Logs not empty."), "doInBackgroundSync-mediaSync");
@@ -137,7 +137,7 @@ public class MediaSyncer {
 
     /**
      * Adds any media sent from the server.
-     * 
+     *
      * @param zip A temporary zip file that contains the media files.
      * @return True if zip is the last in set. Server returns new usn instead.
      */

--- a/src/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/src/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -46,15 +46,15 @@ public class RemoteMediaServer extends BasicHttpSyncer {
         try {
             data.put("fnames", new JSONArray(fnames));
             data.put("minUsn", minUsn);
-            HttpResponse ret = super.req("remove", super.getInputStream(data.toString()));
+            HttpResponse ret = super.req("remove", getInputStream(data.toString()));
             if (ret == null) {
                 return null;
             }
-            String s = "";
+            String s;
             int resultType = ret.getStatusLine().getStatusCode();
             if (resultType == 200) {
                 s = super.stream2String(ret.getEntity().getContent());
-                if (!s.equalsIgnoreCase("null") && s.length() != 0) {
+                if (s != null && !s.equalsIgnoreCase("null") && s.length() != 0) {
                     return new JSONArray(s);
                 }
             }
@@ -74,7 +74,7 @@ public class RemoteMediaServer extends BasicHttpSyncer {
         JSONObject data = new JSONObject();
         try {
             data.put("minUsn", minUsn);
-            HttpResponse ret = super.req("files", super.getInputStream(data.toString()));
+            HttpResponse ret = super.req("files", getInputStream(data.toString()));
             if (ret == null) {
                 Log.e(AnkiDroidApp.TAG, "RemoteMediaServer.files: Exception during request");
                 return null;
@@ -105,16 +105,16 @@ public class RemoteMediaServer extends BasicHttpSyncer {
             }
             StatusLine sl = ret.getStatusLine();
             HttpEntity ent = ret.getEntity();
-            String s = "";
+            String s;
             if (sl != null && sl.getStatusCode() == 200 && ent != null) {
                 s = super.stream2String(ent.getContent());
                 if (s != null && !s.equalsIgnoreCase("null") && s.length() != 0) {
-                	try {
-                        return Long.parseLong(s);                		
-                	} catch (NumberFormatException e) {
-                		AnkiDroidApp.saveExceptionReportFile(e, "RemoteMediaServerAddFiles:" + s);
-                		return 0;
-                	}
+                    try {
+                        return Long.parseLong(s);
+                    } catch (NumberFormatException e) {
+                        AnkiDroidApp.saveExceptionReportFile(e, "RemoteMediaServerAddFiles:" + s);
+                        return 0;
+                    }
                 }
             }
             Log.e(AnkiDroidApp.TAG, "Error in RemoteMediaServer.addFiles(): " + ret.getStatusLine().getReasonPhrase());
@@ -132,7 +132,7 @@ public class RemoteMediaServer extends BasicHttpSyncer {
         if (ret == null) {
             return 0;
         }
-        String s = "";
+        String s;
         int resultType = ret.getStatusLine().getStatusCode();
         if (resultType == 200) {
             try {
@@ -142,7 +142,7 @@ public class RemoteMediaServer extends BasicHttpSyncer {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            if (!s.equalsIgnoreCase("null") && s.length() != 0) {
+            if (s != null && !s.equalsIgnoreCase("null") && s.length() != 0) {
                 return Long.parseLong(s);
             }
         }

--- a/src/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/src/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -109,7 +109,12 @@ public class RemoteMediaServer extends BasicHttpSyncer {
             if (sl != null && sl.getStatusCode() == 200 && ent != null) {
                 s = super.stream2String(ent.getContent());
                 if (s != null && !s.equalsIgnoreCase("null") && s.length() != 0) {
-                    return Long.getLong(s);
+                	try {
+                        return Long.parseLong(s);                		
+                	} catch (NumberFormatException e) {
+                		AnkiDroidApp.saveExceptionReportFile(e, "RemoteMediaServerAddFiles:" + s);
+                		return 0;
+                	}
                 }
             }
             Log.e(AnkiDroidApp.TAG, "Error in RemoteMediaServer.addFiles(): " + ret.getStatusLine().getReasonPhrase());


### PR DESCRIPTION
This is a fix for our sync method.
The problem: If sync produces a sanity error for any reason (there used to be a bug in some shared decks adding, fixed in dev when we brought libanki up to date), then the suggested full sync from the dialog fails.
This full sync attempt, although failed (due to an ankiweb bug, reported) should mark the collection for full sync next time. This second full sync would succeed and fix the problem, but due to this bug that this commit fixes, it doesn't mark it as such, so the next sync will be normal sync which will suffer again from the sanity fail.

Result: If sync sanity fail happens, we can't sync anymore.

This fix correctly bumps the mod time of the collection, when we initiate the first full sync, so that even if this fails, next sync will also be full sync which suceeds (ankiweb only kills the first full sync after sync sanity fail).

Please note that this mod time bumping should only happen when we explicitly request full sync (in anki desktop from the Maintenance menu, in ankidroid from the dialog of sanity fail or deck corruption). If full sync results as conflict during normal sync then, there's no need for this code to run.
