### PR TITLE
V2.0.1 upgrade wizard

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -22,7 +22,7 @@
     package="com.ichi2.anki"
     android:installLocation="auto"
     android:versionCode="31"
-    android:versionName="2.0.1beta1" >
+    android:versionName="2.0.1beta3" >
 
     <instrumentation
         android:name="android.test.InstrumentationTestRunner"

--- a/res/layout/info.xml
+++ b/res/layout/info.xml
@@ -18,18 +18,26 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:orientation="vertical"
     android:layout_width="fill_parent"
-	android:layout_height="fill_parent">
-	<FrameLayout
+	android:layout_height="fill_parent"
+	android:layout_centerVertical="true"
+	android:layout_centerHorizontal="true">
+    	<RelativeLayout
         android:layout_width="fill_parent"
 		android:layout_height="fill_parent"
 		android:layout_alignParentTop="true"
 		android:layout_marginBottom="4dip"
 		android:fadingEdge="vertical"
+		android:gravity="center"
 		android:layout_above="@+id/info_buttons">
-	<WebView
+    	<FrameLayout
+        android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:fadingEdge="vertical">
+    	    	<WebView
         android:id="@+id/info"
-        android:layout_width="fill_parent"
-		android:layout_height="fill_parent"/>
+        android:gravity="center_vertical"
+        android:layout_width="wrap_content"
+		android:layout_height="wrap_content"/>
 	<RelativeLayout
         android:id="@+id/info_loading_layer"
 	    android:background="@color/white"
@@ -43,8 +51,9 @@
         android:layout_width="wrap_content"
 		android:layout_height="wrap_content"/>
 	</RelativeLayout>
-	 
+
 	</FrameLayout>
+		 </RelativeLayout>
 	<LinearLayout  android:id="@+id/info_buttons"
 	    android:layout_width="fill_parent"
 	    android:layout_height="wrap_content"

--- a/res/values-ru/04-network.xml
+++ b/res/values-ru/04-network.xml
@@ -45,8 +45,8 @@
   <string name="connection_error_message">Ошибка сети.</string>
   <string name="sync_log_db_error">Произошла ошибка базы данных.</string>
   <string name="no_user_password_error_message">Для того чтобы продолжить выполнение этой операции, необходимо иметь учетную запись AnkiWeb и войти в AnkiWeb.</string>
-  <string name="username">Имейл</string>
-  <string name="username_repeat">Повторите имейл</string>
+  <string name="username">Электронная почта</string>
+  <string name="username_repeat">Повторите адрес электронной почты</string>
   <string name="password">Пароль</string>
   <string name="password_repeat">Повторите пароль</string>
   <string name="log_in">Войти</string>
@@ -54,8 +54,8 @@
   <string name="sign_up">Зарегистрироваться</string>
   <string name="logged_as">Используется логин</string>
   <string name="log_out">Завершить сеанс</string>
-  <string name="alert_logging_message">Вход в систему, пожалуйста, подождите...</string>
-  <string name="invalid_username_password">Недопустимый имейл или пароль.</string>
+  <string name="alert_logging_message">Вход в систему. Пожалуйста, подождите...</string>
+  <string name="invalid_username_password">Неверный адрес электронной почты или пароль.</string>
   <string name="login_generic_error">Не удалось войти на сервер.</string>
   <string name="download_finished">Загрузка завершена</string>
   <string name="personaldeckpicker_title">Открыть онлайн-колоду</string>

--- a/res/values/01-core.xml
+++ b/res/values/01-core.xml
@@ -180,4 +180,12 @@
 <string name="help_cloze">help</string>
 
 <string name="button_sync">Sync</string>
+    <string name="restart">Restart</string>
+    <string name="do_nothing">Do nothing</string>
+    <string name="more_options">More Options</string>
+    <string name="now">Now</string>
+    <string name="back">Back</string>
+    <string name="ankiweb">AnkiWeb</string>
+    <string name="usb">USB</string>
+    <string name="_import">Import</string>
 </resources>

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -136,5 +136,6 @@
 <string name="import_no_file_found">No importable apkg file found</string>
 <string name="custom_study">Custom Study</string>
   <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
+    <string name="restart_upgrade_process">Restart upgrade process</string>
 
 </resources>

--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -88,5 +88,34 @@
 
 <string name="custom_study_tags">Enter tags:</string>
 <string name="rebuild_custom_study_deck">Rebuilding custom study deck.\nPlease wait...</string>
+    <string name="deck_upgrade_title">Deck Upgrade</string>
+    <string name="deck_upgrade_rename_warning">Be aware that this will rename your collection to \'%1$s\' and
+        will create a new one from your old anki 1.x files. Do you really want to continue?
+    </string>
+    <string name="deck_upgrade_already_upgraded">Did you already upgrade your decks properly after the last AnkiDroid
+        update? If not, you can restart the upgrade process here
+    </string>
+    <string name="deck_upgrade_major_warning">
+        <![CDATA[This is a major update to Ankidroid and the upgrade process will take at least 5-10 minutes.<br><br>Do you want to proceed now or later?<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en\">More info</a>]]></string>
+    <string name="deck_upgrade_start_again_to_upgrade_toast">Please start Ankidroid again when you have time to
+        upgrade!
+    </string>
+    <string name="deck_upgrade_recommended_method">
+        <![CDATA[The recommended upgrade method is to sync with a PC and upgrade with the desktop version of Anki.<br><br>Do you want to upgrade with a PC?]]></string>
+    <string name="deck_upgrade_more_options">
+        <![CDATA[You can create a new empty collection by clicking below.<br><br>If you want to downgrade back to AnkiDroid 1 then please (read <a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Continuing_to_use_AnkiDroid_1.1.3\">these instructions</a>).]]></string>
+    <string name="deck_upgrade_create_new_collection">Create new collection</string>
+    <string name="deck_upgrade_create_new_collection_title">Create New Collection</string>
+    <string name="deck_upgrade_not_import_warning">Are you sure you want to do this? Your old data will not be
+        imported.
+    </string>
+    <string name="deck_upgrade_via_web">
+        <![CDATA[<b>This upgrade method is not recommended if you used media files, or have a big collection!</b><br><br>Your anki1 decks will be zipped and uploaded to AnkiWeb, and the converted collection will then be downloaded.<br><br>Please note that a stable internet connection is required, and that there is a 50MB file limit.<br><br>Users of Anki Desktop are strongly encouraged to use the PC based upgrade method.<br><br>Do you still want to proceed?]]></string>
+    <string name="deck_upgrade_via_anki_desktop">
+        <![CDATA[If you currently have an up-to-date version of your AnkiDroid collection in the Anki desktop software, you can upgrade from there and then download your upgraded collection by syncing with AnkiWeb.<br><br>Alternatively, you can copy your AnkiDroid collection to your PC using USB, then upgrade the collection and copy back to AnkiDroid.]]></string>
+    <string name="deck_upgrade_auto_upgrade">
+        <![CDATA[Please install and start Anki Desktop version 2.0.4 or greater to upgrade your collection, then sync your upgraded collection with AnkiWeb and press the \"Download\" button.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_2:_Using_AnkiWeb_sync\">More detailed information on upgrading using AnkiWeb</a>]]></string>
+    <string name="deck_upgrade_manual">
+        <![CDATA[Please copy all of your *.anki files (and any *.media folders) from your AnkiDroid folder to your Anki Desktop folder, and then install and start Anki Desktop version 2.0.4 or greater to upgrade your collection.<br><br>When the upgrade is completed, please export your collection from Anki2 and copy the collection.apkg file to your AnkiDroid folder and press the Import button below.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_1:_Using_USB_(recommended)\">More detailed information on upgrading using USB.</a>]]></string>
 
 </resources>

--- a/res/values/13-newfeatures.xml
+++ b/res/values/13-newfeatures.xml
@@ -21,7 +21,8 @@
 <resources>
 <!-- Be careful with a reordering. It will probably lead to a deletion of already translated strings on crowdin and should therefore only be done only immediately before release -->
 	<string-array name="new_version_features">
+		<item>upgrade wizard</item>
 		<item>bug fix: importing apkgs</item>
-	        <item>bug fix: media syncing</item>
+			        <item>bug fix: media syncing</item>
 				</string-array>
 </resources>

--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -382,14 +382,16 @@ public class AnkiDroidApp extends Application {
     	mLock.lock();
     	Log.i(AnkiDroidApp.TAG, "closeCollection");
         try {
-        	sInstance.mAccessThreadCount--;
-    		Log.i(AnkiDroidApp.TAG, "Access to collection jas been closed: (count: " + sInstance.mAccessThreadCount + ")");
-        	if (sInstance.mAccessThreadCount == 0 && sInstance.mCurrentCollection != null) {
-        		Collection col = sInstance.mCurrentCollection;
-            	sInstance.mCurrentCollection = null;
-        		col.close(save);
-        	}
-    	} finally {
+            if (sInstance.mAccessThreadCount > 0) {
+                sInstance.mAccessThreadCount--;
+            }
+            Log.i(AnkiDroidApp.TAG, "Access to collection jas been closed: (count: " + sInstance.mAccessThreadCount + ")");
+            if (sInstance.mAccessThreadCount == 0 && sInstance.mCurrentCollection != null) {
+                Collection col = sInstance.mCurrentCollection;
+                sInstance.mCurrentCollection = null;
+                col.close(save);
+            }
+        } finally {
     		mLock.unlock();
     	}
     	

--- a/src/com/ichi2/anki/DeckOptions.java
+++ b/src/com/ichi2/anki/DeckOptions.java
@@ -201,7 +201,7 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
                                 mOptions.getJSONObject("lapse").put("delays", getDelays(steps));
                             }
                         } else if (entry.getKey().equals("lapNewIvl")) {
-                            mOptions.getJSONObject("lapse").put("mult", Float.parseFloat((String) entry.getValue()));
+                            mOptions.getJSONObject("lapse").put("mult", Float.parseFloat((String) entry.getValue()) / 100);
                         } else if (entry.getKey().equals("lapMinIvl")) {
                             mOptions.getJSONObject("lapse").put("minInt", Integer.parseInt((String) entry.getValue()));
                         } else if (entry.getKey().equals("lapLeechThres")) {

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -121,6 +121,7 @@ public class DeckPicker extends FragmentActivity {
     private static final int DIALOG_IMPORT_LOG = 29;
     private static final int DIALOG_IMPORT_HINT = 30;
     private static final int DIALOG_IMPORT_SELECT = 31;
+    public static final String UPGRADE_OLD_COLLECTION_RENAME = "collection.anki2.old";
 
     private String mDialogMessage;
     private int[] mRepairValues;
@@ -1052,18 +1053,18 @@ public class DeckPicker extends FragmentActivity {
 
     private void restartUpgradeProcess() {
         StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-        builder.setTitle("Deck Upgrade");
+        builder.setTitle(R.string.deck_upgrade_title);
         builder.setIcon(R.drawable.ic_dialog_alert);
-        builder.setMessage("Be aware that this will rename your collection to \'collection.old\' and will create a new one from your old anki 1.x files. Do you really want to continue?");
-        builder.setPositiveButton("yes", new DialogInterface.OnClickListener() {
+        builder.setMessage(getString(R.string.deck_upgrade_rename_warning, UPGRADE_OLD_COLLECTION_RENAME));
+        builder.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 String path = AnkiDroidApp.getCollectionPath();
                 int i = 0;
-                String newPath = path.replace("collection.anki2", "collection.old" + i);
+                String newPath = path.replace("collection.anki2", UPGRADE_OLD_COLLECTION_RENAME + i);
                 while ((new File(newPath)).exists()) {
                     i++;
-                    newPath = path.replace("collection.anki2", "collection.old" + i);
+                    newPath = path.replace("collection.anki2", UPGRADE_OLD_COLLECTION_RENAME + i);
                 }
                 (new File(path)).renameTo(new File(newPath));
                 showUpgradeScreen(true, Info.UPGRADE_SCREEN_BASIC1);
@@ -1072,7 +1073,7 @@ public class DeckPicker extends FragmentActivity {
             }
         });
         builder.setCancelable(false);
-        builder.setNegativeButton("no", new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext())
@@ -1138,17 +1139,17 @@ public class DeckPicker extends FragmentActivity {
             if (!preferences.getString("lastUpgradeVersion", "").equals(AnkiDroidApp.getPkgVersion()) &&
                     (new File(AnkiDroidApp.getCurrentAnkiDroidDirectory()).listFiles(new OldAnkiDeckFilter()).length) > 0) {
                 StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-                builder.setTitle("Deck Upgrade");
+                builder.setTitle(R.string.deck_upgrade_title);
                 builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage("Did you already upgrade your decks properly after the last AnkiDroid update? If not, you can restart the upgrade process here");
-                builder.setPositiveButton("Restart", new DialogInterface.OnClickListener() {
+                builder.setMessage(R.string.deck_upgrade_already_upgraded);
+                builder.setPositiveButton(R.string.restart, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         restartUpgradeProcess();
                     }
                 });
                 builder.setCancelable(false);
-                builder.setNegativeButton("Do nothing", new DialogInterface.OnClickListener() {
+                builder.setNegativeButton(R.string.do_nothing, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext())
@@ -2339,7 +2340,7 @@ public class DeckPicker extends FragmentActivity {
         item.setIcon(R.drawable.ic_menu_send);
         item = menu.add(Menu.NONE, MENU_ABOUT, Menu.NONE, R.string.menu_about);
         item.setIcon(R.drawable.ic_menu_info_details);
-        item = menu.add(Menu.NONE, MENU_REUPGRADE, Menu.NONE, "Restart upgrade process");
+        item = menu.add(Menu.NONE, MENU_REUPGRADE, Menu.NONE, R.string.restart_upgrade_process);
         item.setIcon(R.drawable.ic_menu_preferences);
         
         return true;

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -123,12 +123,17 @@ public class DeckPicker extends FragmentActivity {
     private static final int DIALOG_IMPORT_SELECT = 31;
     public static final String UPGRADE_OLD_COLLECTION_RENAME = "collection.anki2.old";
 
+    private static final int IMPORT_METHOD_ASK = 0;
+    private static final int IMPORT_METHOD_ADD = 1;
+    private static final int IMPORT_METHOD_REPLACE = 2;
+
     private String mDialogMessage;
     private int[] mRepairValues;
     private boolean mLoadFailed;
 
     private String mImportPath;
     private String[] mImportValues;
+    private int mImportMethod = IMPORT_METHOD_ASK;
 
     /**
      * Menus
@@ -756,6 +761,80 @@ public class DeckPicker extends FragmentActivity {
     
      };
 
+    DeckTask.TaskListener mImportAddListener = new DeckTask.TaskListener() {
+        @Override
+        public void onPostExecute(DeckTask.TaskData result) {
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                mProgressDialog.dismiss();
+            }
+            if (result.getBoolean()) {
+                Resources res = getResources();
+                int count = result.getInt();
+                if (count < 0) {
+                    if (count == -2) {
+                        mDialogMessage = res.getString(R.string.import_log_no_apkg);
+                    } else {
+                        mDialogMessage = res.getString(R.string.import_log_error);
+                    }
+                    showDialog(DIALOG_IMPORT_LOG);
+                } else {
+                    mDialogMessage = res.getString(R.string.import_log_success, count);
+                    showDialog(DIALOG_IMPORT_LOG);
+                    Object[] info = result.getObjArray();
+                    updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
+                }
+            } else {
+                handleDbError();
+            }
+        }
+        @Override
+        public void onPreExecute() {
+            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
+                mProgressDialog = StyledProgressDialog
+                        .show(DeckPicker.this, getResources().getString(R.string.import_title),
+                                getResources().getString(R.string.import_importing), true, false);
+            }
+        }
+        @Override
+        public void onProgressUpdate(DeckTask.TaskData... values) {
+        }
+    };
+
+    DeckTask.TaskListener mImportReplaceListener = new DeckTask.TaskListener() {
+        @Override
+        public void onPostExecute(DeckTask.TaskData result) {
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                mProgressDialog.dismiss();
+            }
+            if (result.getBoolean()) {
+                Resources res = getResources();
+                int code = result.getInt();
+                if (code == -2) {
+                    mDialogMessage = res.getString(R.string.import_log_no_apkg);
+                }
+                Object[] info = result.getObjArray();
+                updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
+                if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
+                    mOpenCollectionDialog.dismiss();
+                }
+            } else {
+                mDialogMessage = getResources().getString(R.string.import_log_no_apkg);
+                showDialog(DIALOG_IMPORT_LOG);
+            }
+        }
+        @Override
+        public void onPreExecute() {
+            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
+                mProgressDialog = StyledProgressDialog
+                        .show(DeckPicker.this, getResources().getString(R.string.import_title),
+                                getResources().getString(R.string.import_importing), true, false);
+            }
+        }
+        @Override
+        public void onProgressUpdate(DeckTask.TaskData... values) {
+        }
+    };
+
     // ----------------------------------------------------------------------------
     // ANDROID METHODS
     // ----------------------------------------------------------------------------
@@ -1059,6 +1138,7 @@ public class DeckPicker extends FragmentActivity {
         builder.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                AnkiDroidApp.closeCollection(true);
                 String path = AnkiDroidApp.getCollectionPath();
                 int i = 0;
                 String newPath = path.replace("collection.anki2", UPGRADE_OLD_COLLECTION_RENAME + i);
@@ -1658,44 +1738,8 @@ public class DeckPicker extends FragmentActivity {
                 builder.setPositiveButton(res.getString(R.string.import_message_add), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, new DeckTask.TaskListener() {
-                            @Override
-                            public void onPostExecute(DeckTask.TaskData result) {
-                            	if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                                    mProgressDialog.dismiss();
-                                }
-                                if (result.getBoolean()) {
-                                	Resources res = getResources();
-                                	int count = result.getInt();
-                                	if (count < 0) {
-                                		if (count == -2) {
-                                            mDialogMessage = res.getString(R.string.import_log_no_apkg);                                			
-                                		} else {
-                                            mDialogMessage = res.getString(R.string.import_log_error);                                			
-                                		}
-                                        showDialog(DIALOG_IMPORT_LOG);
-                                	} else {
-                                        mDialogMessage = res.getString(R.string.import_log_success, count);
-                                        showDialog(DIALOG_IMPORT_LOG);
-                                        Object[] info = result.getObjArray();
-                                        updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
-                                	}
-                                } else {
-                                	handleDbError();
-                                }
-                            }
-                            @Override
-                            public void onPreExecute() {
-                                if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-                                    mProgressDialog = StyledProgressDialog
-                                            .show(DeckPicker.this, getResources().getString(R.string.import_title),
-                                                    getResources().getString(R.string.import_importing), true, false);
-                                }
-                            }
-                            @Override
-                            public void onProgressUpdate(DeckTask.TaskData... values) {
-                            }
-                        }, new TaskData(AnkiDroidApp.getCol(), mImportPath));
+                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
+                                new TaskData(AnkiDroidApp.getCol(), mImportPath, false));
                         mImportPath = null;
                     }
                 });
@@ -1711,37 +1755,8 @@ public class DeckPicker extends FragmentActivity {
 							@Override
 							public void onClick(DialogInterface dialog,
 									int which) {
-		                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, new DeckTask.TaskListener() {
-		                            @Override
-		                            public void onPostExecute(DeckTask.TaskData result) {
-		                            	if (mProgressDialog != null && mProgressDialog.isShowing()) {
-		                                    mProgressDialog.dismiss();
-		                                }
-		                                if (result.getBoolean()) {
-		                                	Resources res = getResources();
-		                                	int code = result.getInt();
-	                                		if (code == -2) {
-	                                            mDialogMessage = res.getString(R.string.import_log_no_apkg);
-	                                		}
-	                                        Object[] info = result.getObjArray();
-	                                        updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
-		                                } else {
-                                            mDialogMessage = getResources().getString(R.string.import_log_no_apkg);                                			
-                                            showDialog(DIALOG_IMPORT_LOG);
-		                                }
-		                            }
-		                            @Override
-		                            public void onPreExecute() {
-		                                if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-		                                    mProgressDialog = StyledProgressDialog
-		                                            .show(DeckPicker.this, getResources().getString(R.string.import_title),
-		                                                    getResources().getString(R.string.import_importing), true, false);
-		                                }
-		                            }
-		                            @Override
-		                            public void onProgressUpdate(DeckTask.TaskData... values) {
-		                            }
-		                        }, new TaskData(AnkiDroidApp.getCol(), mImportPath));
+		                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener,
+                                        new TaskData(AnkiDroidApp.getCol(), mImportPath));
 		                        mImportPath = null;
 							}
                         	
@@ -2048,11 +2063,25 @@ public class DeckPicker extends FragmentActivity {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                     	mImportPath = mImportValues[which];
-                    	showDialog(DIALOG_IMPORT);
+                        switch (mImportMethod) {
+                            case IMPORT_METHOD_ADD:
+                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
+                                        new TaskData(AnkiDroidApp.getCol(), mImportPath, false));
+                                mImportPath = null;
+                                break;
+                            case IMPORT_METHOD_REPLACE:
+                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener,
+                                        new TaskData(AnkiDroidApp.getCol(), mImportPath));
+                                mImportPath = null;
+                                break;
+                            case IMPORT_METHOD_ASK:
+                            default:
+                                showDialog(DIALOG_IMPORT);
+                        }
+                        mImportMethod = IMPORT_METHOD_ASK;
                     }
                 });
             	break;
-
         }
     }
 
@@ -2554,13 +2583,24 @@ public class DeckPicker extends FragmentActivity {
                 int type = intent.getIntExtra(Info.TYPE_UPGRADE_STAGE, Info.UPGRADE_SCREEN_BASIC1);
                 if (type == Info.UPGRADE_CONTINUE) {
                     showStartupScreensAndDialogs(AnkiDroidApp.getSharedPrefs(getBaseContext()), 3);
-                } else {
-                    if (type == Info.UPGRADE_IMPORT) {
-                        // upgrade by import, set path to non null in order to show the dialog after having opened the collection
-                        mImportPath = "";
+                } else if (type == Info.UPGRADE_IMPORT) {
+                    // upgrade by import, set path to non null in order to show the dialog after having opened the collection
+                    mImportPath = "";
+                    mImportMethod = IMPORT_METHOD_REPLACE;
+                    if (Utils.getImportableDecks().size() == 0) {
+                        Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.import_no_file_found), false);
+                        showUpgradeScreen(true, Info.UPGRADE_SCREEN_MANUAL_UPGRADE, !intent.hasExtra(Info.TYPE_ANINAMTION_RIGHT));
+                    } else {
+                        showDialog(DIALOG_IMPORT_SELECT);
                     }
+                } else {
                     showUpgradeScreen(true, type, !intent.hasExtra(Info.TYPE_ANINAMTION_RIGHT));
                 }
+            } else if (resultCode == RESULT_OK) {
+                if (!AnkiDroidApp.colIsOpen()) {
+                    AnkiDroidApp.openCollection(AnkiDroidApp.getCollectionPath());
+                }
+                loadCounts();
             } else {
                 finishWithAnimation();
             }
@@ -2601,12 +2641,14 @@ public class DeckPicker extends FragmentActivity {
         } else if (requestCode == LOG_IN_FOR_SHARED_DECK && resultCode == RESULT_OK) {
             addSharedDeck();
         } else if (requestCode == ADD_SHARED_DECKS) {
-		if (intent != null) {
-	        	mImportPath = intent.getStringExtra("importPath");
-		}
-        	if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
-        		showDialog(DIALOG_IMPORT);
-        	}
+            if (intent != null) {
+                mImportPath = intent.getStringExtra("importPath");
+            }
+            if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
+                        new TaskData(AnkiDroidApp.getCol(), mImportPath, true));
+                mImportPath = null;
+            }
         } else if (requestCode == REQUEST_REVIEW) {
             Log.i(AnkiDroidApp.TAG, "Result code = " + resultCode);
             switch (resultCode) {

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -40,7 +40,6 @@ import android.widget.Button;
 import android.widget.RelativeLayout;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.async.Connection;
-import com.ichi2.async.Connection.OldAnkiDeckFilter;
 import com.ichi2.async.Connection.Payload;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledDialog;
@@ -66,7 +65,6 @@ import org.apache.http.util.EntityUtils;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLException;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -79,12 +77,24 @@ import java.util.regex.Pattern;
 public class Info extends Activity {
 
     public static final String TYPE_EXTRA = "infoType";
+    public static final String TYPE_UPGRADE_STAGE = "upgradeStage";
+    public static final String TYPE_ANINAMTION_RIGHT = "animationToRight";
 
     public static final int TYPE_ABOUT = 0;
     public static final int TYPE_WELCOME = 1;
     public static final int TYPE_NEW_VERSION = 2;
     public static final int TYPE_SHARED_DECKS = 3;
     public static final int TYPE_UPGRADE_DECKS = 4;
+
+    public static final int UPGRADE_SCREEN_BASIC1 = 0;
+    public static final int UPGRADE_SCREEN_BASIC2 = 1;
+    public static final int UPGRADE_SCREEN_MORE_OPTIONS = 2;
+    public static final int UPGRADE_SCREEN_WEB_UPGRADE = 3;
+    public static final int UPGRADE_SCREEN_PC_UPGRADE = 4;
+    public static final int UPGRADE_SCREEN_MANUAL_UPGRADE = 5;
+    public static final int UPGRADE_SCREEN_AUTO_UPGRADE = 6;
+    public static final int UPGRADE_CONTINUE = 7;
+    public static final int UPGRADE_IMPORT = 8;
 
     private static final int DIALOG_USER_NOT_LOGGED_IN_SYNC = 0;
     private static final int DIALOG_SYNC_LOG = 1;
@@ -95,12 +105,12 @@ public class Info extends Activity {
     private String mDialogMessage;
 
     private int mType;
+    private int mUpgradeStage = -1;
     private WebView mWebView;
     private RelativeLayout mLoadingLayer;
     private String mShareDecksTemplate;
     private StyledProgressDialog mProgressDialog;
     private StyledDialog mNoConnectionAlert;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -118,16 +128,16 @@ public class Info extends Activity {
 
         mWebView = (WebView) findViewById(R.id.info);
         mWebView.setBackgroundColor(res.getColor(Themes.getBackgroundColor()));
-        Themes.setWallpaper((View) mWebView.getParent());
+        Themes.setWallpaper((View) mWebView.getParent().getParent().getParent());
 
         Button continueButton = (Button) findViewById(R.id.info_continue);
         continueButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View arg0) {
-            	if (mType == TYPE_ABOUT) {
-            		Info.this.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.ichi2.anki")));
-            		return;
-            	}
+                if (mType == TYPE_ABOUT) {
+                    Info.this.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.ichi2.anki")));
+                    return;
+                }
                 setResult(RESULT_OK);
                 switch (mType) {
                     case TYPE_WELCOME:
@@ -141,10 +151,7 @@ public class Info extends Activity {
                     case TYPE_UPGRADE_DECKS:
                         break;
                 }
-                finish();
-                if (AnkiDroidApp.SDK_VERSION > 4) {
-                    ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
-                }
+                finishWithAnimation();
             }
         });
 
@@ -197,10 +204,7 @@ public class Info extends Activity {
                         edit.putLong("lastTimeOpened", System.currentTimeMillis());
                         edit.putBoolean("createTutorial", true);
                         edit.commit();
-                        finish();
-                        if (AnkiDroidApp.SDK_VERSION > 4) {
-                            ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
-                        }
+                        finishWithAnimation();
                     }
                 });
                 break;
@@ -224,13 +228,13 @@ public class Info extends Activity {
                 break;
 
             case TYPE_SHARED_DECKS:
-            	mLoadingLayer = (RelativeLayout) findViewById(R.id.info_loading_layer);
+                mLoadingLayer = (RelativeLayout) findViewById(R.id.info_loading_layer);
                 mLoadingLayer.setVisibility(View.VISIBLE);
-    			try {
-    				mShareDecksTemplate = Utils.convertStreamToString(getAssets().open("shared_decks_template.html"));
-    			} catch (IOException e) {
-    				e.printStackTrace();
-    			}
+                try {
+                    mShareDecksTemplate = Utils.convertStreamToString(getAssets().open("shared_decks_template.html"));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
                 mWebView.setWebViewClient(new MobileAnkiWebview());
                 mWebView.loadUrl(res.getString(R.string.shared_decks_url));
                 mWebView.getSettings().setJavaScriptEnabled(true);
@@ -239,55 +243,261 @@ public class Info extends Activity {
 
             case TYPE_UPGRADE_DECKS:
                 sb.append("<html><body>");
-                File[] fileList = (new File(AnkiDroidApp.getCurrentAnkiDroidDirectory())).listFiles(new OldAnkiDeckFilter());
-                StringBuilder fsb = new StringBuilder();
-                fsb.append("<ul>");
-                for (File f : fileList) {
-                	fsb.append("<li>").append(f.getName().replace(".anki", "")).append("</li>");
-                }
-            	fsb.append("</ul>");
-                sb.append(res.getString(R.string.upgrade_decks_message, fsb.toString()));
-                sb.append("<ul><li>");
-                sb.append(res.getString(R.string.upgrade_decks_message_pos1,
-                		AnkiDroidApp.getCurrentAnkiDroidDirectory()));
-                sb.append("</li><li>");
-                sb.append(res.getString(R.string.upgrade_decks_message_pos2, res.getString(R.string.link_anki)));
-                sb.append("</li><li>");
-                sb.append(res.getString(R.string.upgrade_decks_message_pos3));
-                sb.append("</li></ul>");
-                sb.append(res.getString(R.string.upgrade_decks_message_finish));
-                sb.append("</body></html>");
-                mWebView.loadDataWithBaseURL("", sb.toString(), "text/html", "utf-8", null);
 
                 // add upgrade button
                 Button but = (Button) findViewById(R.id.info_tutorial);
                 but.setVisibility(View.VISIBLE);
-                but.setText(res.getString(R.string.upgrade_decks_button));
-                but.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View arg0) {
-                        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-                        } else if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-                            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                        }
-                        Connection.upgradeDecks(mUpgradeListener,
-                                new Connection.Payload(new Object[] { AnkiDroidApp.getCurrentAnkiDroidDirectory() }));
-                    }
-                });
 
                 // add sync button
                 Button syncButton = (Button) findViewById(R.id.info_sync);
                 syncButton.setVisibility(View.VISIBLE);
-                syncButton.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View arg0) {
-                    	downloadCollection();
-                    }
-                });
+
+                mUpgradeStage = getIntent().getIntExtra(TYPE_UPGRADE_STAGE, -1);
+
+                switch (mUpgradeStage) {
+                    case UPGRADE_SCREEN_BASIC1:
+                        sb.append("This is a major update to Ankidroid and the upgrade process will take at least 5-10 minutes.<br><br>Do you want to proceed now or later?<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en\">More info</a>");
+                        but.setText(res.getString(R.string.later));
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Themes.showThemedToast(Info.this, "Please start Ankidroid again when you have time to upgrade!", false);
+                                setResult(RESULT_CANCELED);
+                                finish();
+                            }
+                        });
+                        syncButton.setText("More Options");
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_MORE_OPTIONS);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        continueButton.setText("Now");
+                        continueButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        break;
+
+                    case UPGRADE_SCREEN_BASIC2:
+                        sb.append("The recommended upgrade method is to sync with a PC and upgrade with the desktop version of Anki.<br><br>Do you want to upgrade with a PC?");
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC1);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setText(res.getString(R.string.no));
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_WEB_UPGRADE);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        continueButton.setText(res.getString(R.string.yes));
+                        continueButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_PC_UPGRADE);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        break;
+
+                    case UPGRADE_SCREEN_MORE_OPTIONS:
+                        sb.append("You can create a new empty collection by clicking below.<br><br>If you want to downgrade back to AnkiDroid 1 then please (read <a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Continuing_to_use_AnkiDroid_1.1.3\">these instructions</a>).");
+                        but.setText(res.getString(R.string.upgrade_decks_button));
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC1);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setText("Create new collection");
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                StyledDialog.Builder builder = new StyledDialog.Builder(Info.this);
+                                builder.setTitle("Create New Collection");
+                                builder.setIcon(R.drawable.ic_dialog_alert);
+                                builder.setMessage("Are you sure you want to do this? Your old data will not be imported.");
+                                Resources res = getResources();
+                                builder.setPositiveButton(res.getString(R.string.yes), new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        Intent result = new Intent();
+                                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_CONTINUE);
+                                        setResult(RESULT_OK, result);
+                                        finishWithAnimation();
+                                    }
+                                });
+                                builder.setNegativeButton(res.getString(R.string.no), null);
+                                builder.show();
+                            }
+                        });
+                        continueButton.setVisibility(View.GONE);
+                        break;
+
+                    case UPGRADE_SCREEN_WEB_UPGRADE:
+                        sb.append("<b>This upgrade method is not recommended if you used media files, or have a big collection!</b><br><br>Your anki1 decks will be zipped and uploaded to AnkiWeb, and the converted collection will then be downloaded.<br><br>Please note that a stable internet connection is required, and that there is a 50MB file limit.<br><br>Users of Anki Desktop are strongly encouraged to use the PC based upgrade method.<br><br>Do you still want to proceed?");
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setVisibility(View.GONE);
+                        continueButton.setText(res.getString(R.string.yes));
+                        continueButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+                                } else if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
+                                    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+                                }
+                                Connection.upgradeDecks(mUpgradeListener,
+                                        new Connection.Payload(new Object[]{AnkiDroidApp.getCurrentAnkiDroidDirectory()}));
+                            }
+                        });
+                        break;
+
+                    case UPGRADE_SCREEN_PC_UPGRADE:
+                        sb.append("If you currently have an up-to-date version of your AnkiDroid collection in the Anki desktop software, you can upgrade from there and then download your upgraded collection by syncing with AnkiWeb.<br><br>Alternatively, you can copy your AnkiDroid collection to your PC using USB, then upgrade the collection and copy back to AnkiDroid.");
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setText("USB");
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_MANUAL_UPGRADE);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        continueButton.setText("AnkiWeb");
+                        continueButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_AUTO_UPGRADE);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation();
+                            }
+                        });
+                        break;
+
+                    case UPGRADE_SCREEN_MANUAL_UPGRADE:
+                        sb.append("Please copy all of your *.anki files (and any *.media folders) from your AnkiDroid folder to your Anki Desktop folder, and then install and start Anki Desktop version 2.0.4 or greater to upgrade your collection.<br><br>When the upgrade is completed, please export your collection from Anki2 and copy the collection.apkg file to your AnkiDroid folder and press the Import button below.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_1:_Using_USB_(recommended)\">More detailed information on upgrading using USB.</a>");
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setText("Import");
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_IMPORT);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        continueButton.setVisibility(View.GONE);
+                        break;
+
+                    case UPGRADE_SCREEN_AUTO_UPGRADE:
+                        sb.append("Please install and start Anki Desktop version 2.0.4 or greater to upgrade your collection, then sync your upgraded collection with AnkiWeb and press the \"Download\" button.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_2:_Using_AnkiWeb_sync\">More detailed information on upgrading using AnkiWeb</a>");
+                        but.setText("Back");
+                        but.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                Intent result = new Intent();
+                                result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_PC_UPGRADE);
+                                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                                setResult(RESULT_OK, result);
+                                finishWithAnimation(false);
+                            }
+                        });
+                        syncButton.setText("Download");
+                        syncButton.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View arg0) {
+                                downloadCollection();
+                            }
+                        });
+                        continueButton.setVisibility(View.GONE);
+                        break;
+
+                }
+
+//                File[] fileList = (new File(AnkiDroidApp.getCurrentAnkiDroidDirectory())).listFiles(new OldAnkiDeckFilter());
+//                StringBuilder fsb = new StringBuilder();
+//                fsb.append("<ul>");
+//                for (File f : fileList) {
+//                	fsb.append("<li>").append(f.getName().replace(".anki", "")).append("</li>");
+//                }
+//            	fsb.append("</ul>");
+//                sb.append(res.getString(R.string.upgrade_decks_message, fsb.toString()));
+//                sb.append("<ul><li>");
+//                sb.append(res.getString(R.string.upgrade_decks_message_pos1,
+//                		AnkiDroidApp.getCurrentAnkiDroidDirectory()));
+//                sb.append("</li><li>");
+//                sb.append(res.getString(R.string.upgrade_decks_message_pos2, res.getString(R.string.link_anki)));
+//                sb.append("</li><li>");
+//                sb.append(res.getString(R.string.upgrade_decks_message_pos3));
+//                sb.append("</li></ul>");
+//                sb.append(res.getString(R.string.upgrade_decks_message_finish));
+                sb.append("</body></html>");
+                mWebView.loadDataWithBaseURL("", sb.toString(), "text/html", "utf-8", null);
 
                 StyledDialog.Builder builder2 = new StyledDialog.Builder(this);
-
                 builder2.setTitle(res.getString(R.string.connection_error_title));
                 builder2.setIcon(R.drawable.ic_dialog_alert);
                 builder2.setMessage(res.getString(R.string.connection_needed));
@@ -307,43 +517,43 @@ public class Info extends Activity {
         Resources res = getResources();
         StyledDialog.Builder builder = new StyledDialog.Builder(this);
         switch (id) {
-        case DIALOG_USER_NOT_LOGGED_IN_SYNC:
-            builder.setTitle(res.getString(R.string.connection_error_title));
-            builder.setIcon(R.drawable.ic_dialog_alert);
-            builder.setMessage(res.getString(R.string.no_user_password_error_message));
-            builder.setNegativeButton(res.getString(R.string.cancel), null);
-            builder.setPositiveButton(res.getString(R.string.log_in), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    Intent myAccount = new Intent(Info.this, MyAccount.class);
-                    myAccount.putExtra("notLoggedIn", true);
-                    startActivityForResult(myAccount, LOG_IN_FOR_SYNC);
-                    if (AnkiDroidApp.SDK_VERSION > 4) {
-                        ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.FADE);
-                    }
-                }
-            });
-            dialog = builder.create();
-            break;
+            case DIALOG_USER_NOT_LOGGED_IN_SYNC:
+                builder.setTitle(res.getString(R.string.connection_error_title));
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setMessage(res.getString(R.string.no_user_password_error_message));
+                builder.setNegativeButton(res.getString(R.string.cancel), null);
+                builder.setPositiveButton(res.getString(R.string.log_in), new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                Intent myAccount = new Intent(Info.this, MyAccount.class);
+                                myAccount.putExtra("notLoggedIn", true);
+                                startActivityForResult(myAccount, LOG_IN_FOR_SYNC);
+                                if (AnkiDroidApp.SDK_VERSION > 4) {
+                                    ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.FADE);
+                                }
+                            }
+                        });
+                dialog = builder.create();
+                break;
 
-        case DIALOG_SYNC_LOG:
-            builder.setTitle(res.getString(R.string.sync_log_title));
-            builder.setPositiveButton(res.getString(R.string.ok), null);
-            dialog = builder.create();
-            break;
+            case DIALOG_SYNC_LOG:
+                builder.setTitle(res.getString(R.string.sync_log_title));
+                builder.setPositiveButton(res.getString(R.string.ok), null);
+                dialog = builder.create();
+                break;
 
-        case DIALOG_SYNC_UPGRADE_REQUIRED:
-        	builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_anki)));
-            builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                	downloadCollection();
-                }
-            });
-            builder.setNegativeButton(res.getString(R.string.cancel), null);
-            builder.setTitle(res.getString(R.string.sync_log_title));
-            dialog = builder.create();
-            break;
+            case DIALOG_SYNC_UPGRADE_REQUIRED:
+                builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_anki)));
+                builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                downloadCollection();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.cancel), null);
+                builder.setTitle(res.getString(R.string.sync_log_title));
+                dialog = builder.create();
+                break;
         }
         return dialog;
     }
@@ -353,23 +563,20 @@ public class Info extends Activity {
         Resources res = getResources();
         StyledDialog ad = (StyledDialog) dialog;
         switch (id) {
-    
-        case DIALOG_SYNC_LOG:
-        	ad.setMessage(mDialogMessage);
-        	break;
+            case DIALOG_SYNC_LOG:
+                ad.setMessage(mDialogMessage);
+                break;
         }
     }
 
-    
     private void downloadCollection() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         String hkey = preferences.getString("hkey", "");
         if (hkey.length() == 0) {
             showDialog(DIALOG_USER_NOT_LOGGED_IN_SYNC);
         } else {
-            Connection.sync(mSyncListener, new Connection.Payload(new Object[] { hkey, 
-                    preferences.getBoolean("syncFetchesMedia", true),
-                    "download", 0 }));
+            Connection.sync(mSyncListener, new Connection.Payload(new Object[]{
+                    hkey, preferences.getBoolean("syncFetchesMedia", true), "download", 0}));
         }
     }
 
@@ -377,28 +584,54 @@ public class Info extends Activity {
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
         if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
-        	downloadCollection();
+            downloadCollection();
         }
     }
-    
+
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
             if (mType == TYPE_SHARED_DECKS && mWebView.canGoBack()) {
                 mWebView.goBack();
+            } else if (mType == TYPE_UPGRADE_DECKS && mUpgradeStage != UPGRADE_SCREEN_BASIC1) {
+                Intent result = new Intent();
+                result.putExtra(TYPE_ANINAMTION_RIGHT, true);
+                switch (mUpgradeStage) {
+                    case UPGRADE_SCREEN_BASIC2:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC1);
+                        break;
+
+                    case UPGRADE_SCREEN_MORE_OPTIONS:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC1);
+                        break;
+
+                    case UPGRADE_SCREEN_WEB_UPGRADE:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                        break;
+
+                    case UPGRADE_SCREEN_PC_UPGRADE:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                        break;
+
+                    case UPGRADE_SCREEN_MANUAL_UPGRADE:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_BASIC2);
+                        break;
+
+                    case UPGRADE_SCREEN_AUTO_UPGRADE:
+                        result.putExtra(TYPE_UPGRADE_STAGE, UPGRADE_SCREEN_PC_UPGRADE);
+                        break;
+                }
+                setResult(RESULT_OK, result);
+                finishWithAnimation(false);
             } else {
                 Log.i(AnkiDroidApp.TAG, "Info - onBackPressed()");
                 setResult(RESULT_CANCELED);
-                finish();
-                if (AnkiDroidApp.SDK_VERSION > 4) {
-                    ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
-                }
+                finishWithAnimation();
             }
             return true;
         }
         return super.onKeyDown(keyCode, event);
     }
-
 
     private String getTitleString() {
         StringBuilder appName = new StringBuilder();
@@ -409,9 +642,9 @@ public class Info extends Activity {
     }
 
     private class MobileAnkiWebview extends WebViewClient {
-    	WebView mWebView;
-    	String mUrl;
-    	
+        WebView mWebView;
+        String mUrl;
+
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
             Log.i(AnkiDroidApp.TAG, "LoadSharedDecks: loading: " + url);
@@ -421,18 +654,18 @@ public class Info extends Activity {
 
         @Override
         public void onPageStarted(WebView view, String url, Bitmap favicon) {
-        	if (mUrl != null && mUrl.equals(url)) {
-        		super.onPageStarted(view, url, favicon);
-        	} else if (url.matches(".*/shared/download/[0-9]*")) {
+            if (mUrl != null && mUrl.equals(url)) {
+                super.onPageStarted(view, url, favicon);
+            } else if (url.matches(".*/shared/download/[0-9]*")) {
                 Connection.downloadSharedDeck(mDownloadDeckListener,
-                        new Connection.Payload(new Object[] { url }));
-        	} else {
-        		mLoadingLayer.setVisibility(View.VISIBLE);
+                        new Connection.Payload(new Object[]{url}));
+            } else {
+                mLoadingLayer.setVisibility(View.VISIBLE);
                 mWebView = view;
                 mUrl = url;
                 AsyncTask<String, Void, String> parseShareDecks = new ParseSharedDecks();
-                parseShareDecks.execute(url);        		
-        	}
+                parseShareDecks.execute(url);
+            }
         }
 
         private class ParseSharedDecks extends AsyncTask<String, Void, String> {
@@ -458,9 +691,9 @@ public class Info extends Activity {
                 ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(httpParams, registry);
 
                 ResponseHandler<String> handler = new ResponseHandler<String>() {
-    				@Override
-    				public String handleResponse(HttpResponse response)
-    						throws ClientProtocolException, IOException {
+                    @Override
+                    public String handleResponse(HttpResponse response)
+                            throws ClientProtocolException, IOException {
                         HttpEntity entity = response.getEntity();
                         String html;
                         if (entity != null) {
@@ -469,21 +702,21 @@ public class Info extends Activity {
                         } else {
                             return null;
                         }
-    				}
+                    }
                 };
 
                 String pageHTML = null;
                 try {
                     HttpClient client = new DefaultHttpClient(cm, httpParams);
-                    while (pageHTML == null){
+                    while (pageHTML == null) {
                         pageHTML = client.execute(pageGet, handler);
                     }
                 } catch (ClientProtocolException e) {
-                	pageHTML = "ClientProtocolException: " + e.getMessage();
+                    pageHTML = "ClientProtocolException: " + e.getMessage();
                 } catch (SSLException e) {
                     pageHTML = "SSLException: " + e.getMessage();
                 } catch (IOException e) {
-                	pageHTML = "IOException: " + e.getMessage();
+                    pageHTML = "IOException: " + e.getMessage();
                 }
 
                 Pattern pattern = Pattern.compile("</*div(\\sid=\\\"content\\\")*");
@@ -492,25 +725,25 @@ public class Info extends Activity {
                 int end = 0;
                 int inner = 0;
                 while (matcher.find()) {
-                	if (matcher.group().length() > 8) {
-                		start = matcher.start();
-                	} else if (start >= 0) {
-                		if (matcher.group().equals("<div")) {
-                			inner++;
-                		} else {
-                			if (inner == 0) {
-                				end = matcher.end();
-                				break;
-                			} else {
-                				inner--;
-                			}
-                		}
-                	}
+                    if (matcher.group().length() > 8) {
+                        start = matcher.start();
+                    } else if (start >= 0) {
+                        if (matcher.group().equals("<div")) {
+                            inner++;
+                        } else {
+                            if (inner == 0) {
+                                end = matcher.end();
+                                break;
+                            } else {
+                                inner--;
+                            }
+                        }
+                    }
                 }
                 if (start == -1 || end <= 0) {
-                	return "error";
+                    return "error";
                 } else {
-                	return mShareDecksTemplate.replace("::content::",  pageHTML.substring(start, end)).replaceAll(">\nDownload(.|\n)*", ">Import</a></div>");
+                    return mShareDecksTemplate.replace("::content::",  pageHTML.substring(start, end)).replaceAll(">\nDownload(.|\n)*", ">Import</a></div>");
                 }
             }
 
@@ -526,7 +759,6 @@ public class Info extends Activity {
 
     }
 
-
     Connection.TaskListener mUpgradeListener = new Connection.TaskListener() {
 
         @Override
@@ -539,7 +771,6 @@ public class Info extends Activity {
             }
         }
 
-
         @Override
         public void onPreExecute() {
             Log.i(AnkiDroidApp.TAG, "Info: UpgradeDecks - onPreExcecute");
@@ -549,17 +780,16 @@ public class Info extends Activity {
             }
         }
 
-
         @Override
         public void onPostExecute(Payload data) {
-            Log.i(AnkiDroidApp.TAG, "Info: UpgradeDecks - onPostExecute, succes = " + data.success);
-        	Resources res = getResources();
+            Log.i(AnkiDroidApp.TAG, "Info: UpgradeDecks - onPostExecute, success = " + data.success);
+            Resources res = getResources();
             try {
                 if (mProgressDialog != null && mProgressDialog.isShowing()) {
                     mProgressDialog.dismiss();
-                }            	
+                }
             } catch (IllegalArgumentException e) {
-            	Log.e(AnkiDroidApp.TAG, "Info - IllegalArgumentException: " + e);
+                Log.e(AnkiDroidApp.TAG, "Info - IllegalArgumentException: " + e);
             }
 
             if (data.success) {
@@ -596,18 +826,15 @@ public class Info extends Activity {
                     }
                     builder.setMessage(failures);
                     builder.setPositiveButton(res.getString(R.string.ok), new Dialog.OnClickListener() {
-
-						@Override
-						public void onClick(DialogInterface dialog, int which) {
-		            		setResult(RESULT_OK);
-		                    finish();
-		                    if (AnkiDroidApp.SDK_VERSION > 4) {
-		                        ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
-		                    }
-						}});
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    setResult(RESULT_OK);
+                                    finishWithAnimation();
+                                }
+                            });
                     builder.setCancelable(false);
                     builder.show();
-            	}
+                }
             } else {
                 StyledDialog.Builder builder = new StyledDialog.Builder(Info.this);
                 builder.setTitle(res.getString(R.string.connection_error_title));
@@ -618,7 +845,6 @@ public class Info extends Activity {
             }
         }
 
-
         @Override
         public void onDisconnected() {
             if (mNoConnectionAlert != null) {
@@ -626,10 +852,10 @@ public class Info extends Activity {
             }
         }
     };
-    
+
     Connection.TaskListener mDownloadDeckListener = new Connection.TaskListener() {
-    	int countDown = 0;
-    	
+        int countDown = 0;
+
         @Override
         public void onProgressUpdate(Object... values) {
             countDown = ((Integer) values[0]).intValue();
@@ -639,33 +865,31 @@ public class Info extends Activity {
             }
         }
 
-
         @Override
         public void onPreExecute() {
             Log.i(AnkiDroidApp.TAG, "Info: mDownloadDeckListener - onPreExcecute");
             if (mProgressDialog == null || !mProgressDialog.isShowing()) {
                 mProgressDialog = StyledProgressDialog.show(Info.this, "",
-                		getResources().getString(R.string.download_deck, countDown / 1024), true);
+                        getResources().getString(R.string.download_deck, countDown / 1024), true);
             }
         }
 
-
         @Override
         public void onPostExecute(Payload data) {
-            Log.i(AnkiDroidApp.TAG, "Info: mDownloadDeckListener - onPostExecute, succes = " + data.success);
-        	Resources res = getResources();
+            Log.i(AnkiDroidApp.TAG, "Info: mDownloadDeckListener - onPostExecute, success = " + data.success);
+            Resources res = getResources();
             try {
                 if (mProgressDialog != null && mProgressDialog.isShowing()) {
                     mProgressDialog.dismiss();
-                }            	
+                }
             } catch (IllegalArgumentException e) {
-            	Log.e(AnkiDroidApp.TAG, "Info - IllegalArgumentException: " + e);
+                Log.e(AnkiDroidApp.TAG, "Info - IllegalArgumentException: " + e);
             }
 
             if (data.success) {
-            	Intent intent = new Intent();
-            	intent.putExtra("importPath", (String) data.result);
-            	setResult(RESULT_OK, intent);
+                Intent intent = new Intent();
+                intent.putExtra("importPath", (String) data.result);
+                setResult(RESULT_OK, intent);
                 finish();
                 if (AnkiDroidApp.SDK_VERSION > 4) {
                     ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
@@ -680,7 +904,6 @@ public class Info extends Activity {
             }
         }
 
-
         @Override
         public void onDisconnected() {
             if (mNoConnectionAlert != null) {
@@ -688,13 +911,12 @@ public class Info extends Activity {
             }
         }
     };
-    
+
     private Connection.TaskListener mSyncListener = new Connection.TaskListener() {
 
         String currentMessage;
         long countUp;
         long countDown;
-
 
         @Override
         public void onDisconnected() {
@@ -702,7 +924,6 @@ public class Info extends Activity {
                 mNoConnectionAlert.show();
             }
         }
-
 
         @Override
         public void onPreExecute() {
@@ -716,7 +937,6 @@ public class Info extends Activity {
                                 true, false);
             }
         }
-
 
         @Override
         public void onProgressUpdate(Object... values) {
@@ -743,7 +963,6 @@ public class Info extends Activity {
                         + res.getString(R.string.sync_up_down_size, countUp / 1024, countDown / 1024));
             }
         }
-
 
         @Override
         public void onPostExecute(Payload data) {
@@ -783,7 +1002,7 @@ public class Info extends Activity {
                     } else if (resultType.equals("upgradeRequired")) {
                         showDialog(DIALOG_SYNC_UPGRADE_REQUIRED);
                     } else {
-                    	if (result.length > 1 && result[1] instanceof Integer) {
+                        if (result.length > 1 && result[1] instanceof Integer) {
                             int type = (Integer) result[1];
                             switch (type) {
                                 case 503:
@@ -793,22 +1012,30 @@ public class Info extends Activity {
                                     mDialogMessage = res.getString(R.string.sync_log_error_specific,
                                             Integer.toString(type), (String) result[2]);
                                     break;
-                            }                    		
-                    	} else if (result[0] instanceof String) {
-                            mDialogMessage = res.getString(R.string.sync_log_error_specific,
-                                    -1, (String) result[0]);
-                    	} else {
+                            }
+                        } else if (result[0] instanceof String) {
+                            mDialogMessage = res.getString(R.string.sync_log_error_specific, -1, (String) result[0]);
+                        } else {
                             mDialogMessage = res.getString(R.string.sync_generic_error);
-                    	}
+                        }
                     }
                 }
             } else {
                 setResult(RESULT_OK);
-                finish();
-                if (AnkiDroidApp.SDK_VERSION > 4) {
-                    ActivityTransitionAnimation.slide(Info.this, ActivityTransitionAnimation.LEFT);
-                }
+                finishWithAnimation();
             }
         }
     };
+
+    private void finishWithAnimation() {
+        finishWithAnimation(true);
+    }
+
+    private void finishWithAnimation(boolean left) {
+        finish();
+        if (AnkiDroidApp.SDK_VERSION > 4) {
+            ActivityTransitionAnimation.slide(Info.this, left ?
+                    ActivityTransitionAnimation.LEFT : ActivityTransitionAnimation.RIGHT);
+        }
+    }
 }

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -41,6 +41,7 @@ import android.widget.RelativeLayout;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
+import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledDialog;
 import com.ichi2.themes.StyledProgressDialog;

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -256,17 +256,17 @@ public class Info extends Activity {
 
                 switch (mUpgradeStage) {
                     case UPGRADE_SCREEN_BASIC1:
-                        sb.append("This is a major update to Ankidroid and the upgrade process will take at least 5-10 minutes.<br><br>Do you want to proceed now or later?<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en\">More info</a>");
-                        but.setText(res.getString(R.string.later));
+                        sb.append(getString(R.string.deck_upgrade_major_warning));
+                        but.setText(R.string.later);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
-                                Themes.showThemedToast(Info.this, "Please start Ankidroid again when you have time to upgrade!", false);
+                                Themes.showThemedToast(Info.this, getString(R.string.deck_upgrade_start_again_to_upgrade_toast), false);
                                 setResult(RESULT_CANCELED);
                                 finish();
                             }
                         });
-                        syncButton.setText("More Options");
+                        syncButton.setText(R.string.more_options);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -276,7 +276,7 @@ public class Info extends Activity {
                                 finishWithAnimation();
                             }
                         });
-                        continueButton.setText("Now");
+                        continueButton.setText(R.string.now);
                         continueButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -289,8 +289,8 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_BASIC2:
-                        sb.append("The recommended upgrade method is to sync with a PC and upgrade with the desktop version of Anki.<br><br>Do you want to upgrade with a PC?");
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_recommended_method));
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -301,7 +301,7 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText(res.getString(R.string.no));
+                        syncButton.setText(android.R.string.no);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -311,7 +311,7 @@ public class Info extends Activity {
                                 finishWithAnimation();
                             }
                         });
-                        continueButton.setText(res.getString(R.string.yes));
+                        continueButton.setText(android.R.string.yes);
                         continueButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -324,9 +324,9 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_MORE_OPTIONS:
-                        sb.append("You can create a new empty collection by clicking below.<br><br>If you want to downgrade back to AnkiDroid 1 then please (read <a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Continuing_to_use_AnkiDroid_1.1.3\">these instructions</a>).");
-                        but.setText(res.getString(R.string.upgrade_decks_button));
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_more_options));
+                        but.setText(R.string.upgrade_decks_button);
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -337,16 +337,16 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText("Create new collection");
+                        syncButton.setText(R.string.deck_upgrade_create_new_collection);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
                                 StyledDialog.Builder builder = new StyledDialog.Builder(Info.this);
-                                builder.setTitle("Create New Collection");
+                                builder.setTitle(R.string.deck_upgrade_create_new_collection_title);
                                 builder.setIcon(R.drawable.ic_dialog_alert);
-                                builder.setMessage("Are you sure you want to do this? Your old data will not be imported.");
+                                builder.setMessage(R.string.deck_upgrade_not_import_warning);
                                 Resources res = getResources();
-                                builder.setPositiveButton(res.getString(R.string.yes), new DialogInterface.OnClickListener() {
+                                builder.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialog, int which) {
                                         Intent result = new Intent();
@@ -355,7 +355,7 @@ public class Info extends Activity {
                                         finishWithAnimation();
                                     }
                                 });
-                                builder.setNegativeButton(res.getString(R.string.no), null);
+                                builder.setNegativeButton(android.R.string.no, null);
                                 builder.show();
                             }
                         });
@@ -363,8 +363,8 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_WEB_UPGRADE:
-                        sb.append("<b>This upgrade method is not recommended if you used media files, or have a big collection!</b><br><br>Your anki1 decks will be zipped and uploaded to AnkiWeb, and the converted collection will then be downloaded.<br><br>Please note that a stable internet connection is required, and that there is a 50MB file limit.<br><br>Users of Anki Desktop are strongly encouraged to use the PC based upgrade method.<br><br>Do you still want to proceed?");
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_via_web));
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -376,7 +376,7 @@ public class Info extends Activity {
                             }
                         });
                         syncButton.setVisibility(View.GONE);
-                        continueButton.setText(res.getString(R.string.yes));
+                        continueButton.setText(android.R.string.yes);
                         continueButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -392,8 +392,8 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_PC_UPGRADE:
-                        sb.append("If you currently have an up-to-date version of your AnkiDroid collection in the Anki desktop software, you can upgrade from there and then download your upgraded collection by syncing with AnkiWeb.<br><br>Alternatively, you can copy your AnkiDroid collection to your PC using USB, then upgrade the collection and copy back to AnkiDroid.");
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_via_anki_desktop));
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -404,7 +404,7 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText("USB");
+                        syncButton.setText(R.string.usb);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -414,7 +414,7 @@ public class Info extends Activity {
                                 finishWithAnimation();
                             }
                         });
-                        continueButton.setText("AnkiWeb");
+                        continueButton.setText(R.string.ankiweb);
                         continueButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -427,8 +427,8 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_MANUAL_UPGRADE:
-                        sb.append("Please copy all of your *.anki files (and any *.media folders) from your AnkiDroid folder to your Anki Desktop folder, and then install and start Anki Desktop version 2.0.4 or greater to upgrade your collection.<br><br>When the upgrade is completed, please export your collection from Anki2 and copy the collection.apkg file to your AnkiDroid folder and press the Import button below.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_1:_Using_USB_(recommended)\">More detailed information on upgrading using USB.</a>");
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_manual));
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -439,7 +439,7 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText("Import");
+                        syncButton.setText(R.string._import);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -453,8 +453,8 @@ public class Info extends Activity {
                         break;
 
                     case UPGRADE_SCREEN_AUTO_UPGRADE:
-                        sb.append("Please install and start Anki Desktop version 2.0.4 or greater to upgrade your collection, then sync your upgraded collection with AnkiWeb and press the \"Download\" button.<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en#Option_2:_Using_AnkiWeb_sync\">More detailed information on upgrading using AnkiWeb</a>");
-                        but.setText("Back");
+                        sb.append(getString(R.string.deck_upgrade_auto_upgrade));
+                        but.setText(R.string.back);
                         but.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -465,7 +465,7 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText("Download");
+                        syncButton.setText(R.string.download);
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -518,11 +518,11 @@ public class Info extends Activity {
         StyledDialog.Builder builder = new StyledDialog.Builder(this);
         switch (id) {
             case DIALOG_USER_NOT_LOGGED_IN_SYNC:
-                builder.setTitle(res.getString(R.string.connection_error_title));
+                builder.setTitle(R.string.connection_error_title);
                 builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage(res.getString(R.string.no_user_password_error_message));
-                builder.setNegativeButton(res.getString(R.string.cancel), null);
-                builder.setPositiveButton(res.getString(R.string.log_in), new DialogInterface.OnClickListener() {
+                builder.setMessage(R.string.no_user_password_error_message);
+                builder.setNegativeButton(R.string.cancel, null);
+                builder.setPositiveButton(R.string.log_in, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 Intent myAccount = new Intent(Info.this, MyAccount.class);
@@ -537,21 +537,21 @@ public class Info extends Activity {
                 break;
 
             case DIALOG_SYNC_LOG:
-                builder.setTitle(res.getString(R.string.sync_log_title));
-                builder.setPositiveButton(res.getString(R.string.ok), null);
+                builder.setTitle(R.string.sync_log_title);
+                builder.setPositiveButton(android.R.string.ok, null);
                 dialog = builder.create();
                 break;
 
             case DIALOG_SYNC_UPGRADE_REQUIRED:
                 builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_anki)));
-                builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
+                builder.setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 downloadCollection();
                             }
                         });
-                builder.setNegativeButton(res.getString(R.string.cancel), null);
-                builder.setTitle(res.getString(R.string.sync_log_title));
+                builder.setNegativeButton(android.R.string.cancel, null);
+                builder.setTitle(R.string.sync_log_title);
                 dialog = builder.create();
                 break;
         }
@@ -692,8 +692,7 @@ public class Info extends Activity {
 
                 ResponseHandler<String> handler = new ResponseHandler<String>() {
                     @Override
-                    public String handleResponse(HttpResponse response)
-                            throws ClientProtocolException, IOException {
+                    public String handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
                         HttpEntity entity = response.getEntity();
                         String html;
                         if (entity != null) {
@@ -743,7 +742,8 @@ public class Info extends Activity {
                 if (start == -1 || end <= 0) {
                     return "error";
                 } else {
-                    return mShareDecksTemplate.replace("::content::",  pageHTML.substring(start, end)).replaceAll(">\nDownload(.|\n)*", ">Import</a></div>");
+                    return mShareDecksTemplate.replace("::content::",
+                            pageHTML.substring(start, end)).replaceAll(">\nDownload(.|\n)*", ">Import</a></div>");
                 }
             }
 

--- a/src/com/ichi2/async/Connection.java
+++ b/src/com/ichi2/async/Connection.java
@@ -305,6 +305,7 @@ public class Connection extends AsyncTask<Connection.Payload, Object, Connection
             data.data = new Object[] { "wrong anki directory" };
             return data;
         }
+
         // step 1: gather all .anki files into a zip, without media.
         // we must store them as 1.anki, 2.anki and provide a map so we don't run into
         // encoding issues with the zip file.
@@ -312,7 +313,7 @@ public class Connection extends AsyncTask<Connection.Payload, Object, Connection
         JSONObject map = new JSONObject();
         byte[] buf = new byte[1024];
         String zipFilename = path + "/upload.zip";
-        String colFilename = path + "/collection.anki2";
+        String colFilename = path + AnkiDroidApp.COLLECTION_PATH;
         try {
             ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFilename));
             int n = 1;
@@ -443,7 +444,6 @@ public class Connection extends AsyncTask<Connection.Payload, Object, Connection
                 }
             }
             File newMediaDir = new File(col.getMedia().getDir());
-            AnkiDroidApp.closeCollection(false);
 
             // step 6. move media files to new media directory
             publishProgress(new Object[] { R.string.upgrade_decks_media });


### PR DESCRIPTION
This was based upon the work done by Norbert, with the following changes:
- Externalized message strings for capability of translation
- Fixed a manual upgrade issue mentioned in issue 1580.
- Changed the importing behaviour a bit so that the Add/Replace doesn't appear in the following two cases:
  a) Shared decks. They are always added and no import dialog appears to the user.
  b) Importing during the upgrade wizard. This does replacing. A dialog appears to let the user decide which .apkg file has their collection.
- Cleaned up the shared deck tmp file, after the download finishes. This was left over before in AnkiDroid folder and is an .apkg, so it would appear as available for import when doing re-upgrade, or simple "Import cards".
