### PR TITLE
V2.0.1 libanki update to anki v2.0.5

### DIFF
--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -460,14 +460,28 @@ public class Collection {
         return (int) mDb.queryScalar("SELECT count() FROM notes");
     }
 
-
+    /**
+     * Return a new note with the default model from the deck
+     * @return The new note
+     */
     public Note newNote() {
-        return newNote(mModels.current());
+        return newNote(true);
     }
 
+    /**
+     * Return a new note with the model derived from the deck or the configuration
+     * @param forDeck When true it uses the model specified in the deck (mid), otherwise it uses the model specified in
+     *                the configuration (curModel)
+     * @return The new note
+     */
+    public Note newNote(boolean forDeck) {
+        return newNote(mModels.current(forDeck));
+    }
 
     /**
-     * Return a new note with the current model.
+     * Return a new note with a specific model
+     * @param m The model to use for the new note
+     * @return The new note
      */
     public Note newNote(JSONObject m) {
         return new Note(this, m);

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -59,7 +59,7 @@ public class Collection {
     public static final int SCHEMA_VERSION = 11;
     public static final String SYNC_URL = "https://ankiweb.net/";
     public static final int SYNC_VER = 5;
-    public static final String HELP_SITE = "http://ankisrs.net/docs/dev/manual.html";
+    public static final String HELP_SITE = "http://ankisrs.net/docs/manual.html";
 
     private AnkiDb mDb;
     private boolean mServer;

--- a/src/com/ichi2/libanki/Finder.java
+++ b/src/com/ichi2/libanki/Finder.java
@@ -49,6 +49,7 @@ public class Finder {
             .compile("(-)?\\'(([^\\'\\\\]|\\\\.)*)\\'|(-)?\"(([^\"\\\\]|\\\\.)*)\"|(-)?([^ ]+)|([ ]+)");
     private static final Pattern fPropPattern = Pattern.compile("(^.+?)(<=|>=|!=|=|<|>)(.+?$)");
     private static final Pattern fNidsPattern = Pattern.compile("[^0-9,]");
+    private static final Pattern fMidPattern = Pattern.compile("[^0-9]");
 
     private static final List<String> fValidEases = Arrays.asList(new String[] { "1", "2", "3", "4" });
     private static final List<String> fValidProps = Arrays
@@ -290,6 +291,8 @@ public class Finder {
                     addPred(s, _findTemplate(val));
                 } else if (cmd.equals("note")) {
                     addPred(s, _findModel(val));
+                } else if (cmd.equals("mid")) {
+                    addPred(s, _findMid(val));
                 } else if (cmd.equals("deck")) {
                     addPred(s, _findDeck(val));
                 } else if (cmd.equals("prop")) {
@@ -560,6 +563,12 @@ public class Finder {
         return "n.id in (" + val + ")";
     }
 
+    private String _findMid(String val) {
+        if (fMidPattern.matcher(val).find()) {
+            return "";
+        }
+        return "n.mid = " + val;
+    }
 
     private String _findModel(String val) {
         LinkedList<Long> ids = new LinkedList<Long>();

--- a/src/com/ichi2/libanki/Models.java
+++ b/src/com/ichi2/libanki/Models.java
@@ -210,25 +210,32 @@ public class Models {
 
     /**
      * Get current model.
+     * @return The JSONObject of the model, or null if not found in the deck and in the configuration.
      */
     public JSONObject current() {
-        JSONObject m;
-        try {
-            JSONObject curDeck = mCol.getDecks().current();
-            if (curDeck.has("mid")) {
-                m = get(mCol.getDecks().current().getLong("mid"));
-            } else {
-                m = get(mCol.getConf().getLong("curModel"));
-            }
-            if (m == null) {
-                if (!mModels.isEmpty()) {
-                    m = mModels.values().iterator().next();
-                }
-            }
-            return m;
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
+        return current(true);
+    }
+
+    /**
+     * Get current model.
+     * @param forDeck If true, it tries to get the deck specified in deck by mid, otherwise or if the former is not
+     *                found, it uses the configuration`s field curModel.
+     * @return The JSONObject of the model, or null if not found in the deck and in the configuration.
+     */
+    public JSONObject current(boolean forDeck) {
+        JSONObject m = null;
+        if (forDeck) {
+            m = get(mCol.getDecks().current().optLong("mid", -1));
         }
+        if (m == null) {
+            m = get(mCol.getConf().optLong("curModel", -1));
+        }
+        if (m == null) {
+            if (!mModels.isEmpty()) {
+                m = mModels.values().iterator().next();
+            }
+        }
+        return m;
     }
 
 

--- a/src/com/ichi2/libanki/Sched.java
+++ b/src/com/ichi2/libanki/Sched.java
@@ -2347,11 +2347,13 @@ public class Sched {
 
     /**
      * Bury all cards for note until next session.
+     * @param nid The id of the targetted note.
      */
     public void buryNote(long nid) {
         mCol.setDirty();
         long[] cids = Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
                 "SELECT id FROM cards WHERE nid = " + nid + " AND queue >= 0", 0));
+        removeLrn(cids);
         mCol.getDb().execute("UPDATE cards SET queue = -2 WHERE id IN " + Utils.ids2str(cids));
     }
 

--- a/src/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/src/com/ichi2/libanki/importer/Anki2Importer.java
@@ -591,8 +591,10 @@ public class Anki2Importer {
         try {
             Utils.writeToFile(is, fname);
         } catch (IOException e) {
-            Log.e(AnkiDroidApp.TAG, "Anki2Importer._writeDstMedia: error while copying file", e);
-            throw new RuntimeException(e);
+            // the user likely used subdirectories
+            Log.e(AnkiDroidApp.TAG, String.format(Locale.US,
+                    "Anki2Importer._writeDstMedia: error copying file to %s (%s), ignoring and continuing.", fname,
+                    e.getMessage()));
         }
     }
 


### PR DESCRIPTION
All the relevant libanki changes from anki 2.0.4 to 2.0.5
Notable changes:
- Importing decks with media that have subdirectories (invalid) won't fail the import anymore, just ignore the errors.
- Fixed a libanki bug with bury cards

There is an extra applicable change dae/anki 23650f6ee0 that affects card rendering that I skipped. The reason is that it gets reverted in the next version of anki (2.0.6 not released yet, so not ported yet).
