### PR TITLE
Fix timeboxing and clean up old session code

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -37,8 +37,6 @@
 <string name="show_whiteboard">Show Whiteboard</string>
 <string name="hide_whiteboard">Hide Whiteboard</string>
 <string name="clear_whiteboard">Clear Whiteboard</string>
-<string name="session_question_limit_reached">Session question limit reached</string>
-<string name="session_time_limit_reached">Session time limit reached</string>
 <string name="cram_edit_warning">Card editing not allowed while cramming</string>
 <string name="suspend_leeches">Suspend Leeches</string>
 <string name="leech_suspend_notification">Card marked as leech and suspended</string>
@@ -63,7 +61,15 @@
 
 <string name="saving_changes">Saving changes...</string>
 
-<string name="timebox_reached">Timebox reached!</string>
+<plurals name="timebox_reached">
+  <item quantity="one">1 card studied in %2$s</item>
+  <item quantity="other">%1$d cards studied in %2$s</item>
+</plurals>
+
+<plurals name="timebox_reached_minutes">
+  <item quantity="one">1 minute</item>
+  <item quantity="other">%1$d minutes</item>
+</plurals>
 
 <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
 <string name="studyoptions_no_external_storage_title">No External Storage Available</string>

--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -52,8 +52,6 @@
 <string name="show_study_options_on_deck_load_summ">Shows study options screen when loading a deck</string>
 <string name="hide_due_count">Hide due count</string>
 <string name="hide_due_count_summ">Hides the due count</string>
-<string name="overtime">Overtime</string>
-<string name="overtime_summ">Continue reviewing after time limit reached</string>
 <string name="show_progress_bars">Show progress bars</string>
 <string name="show_progress_bars_summ">Shows today\'s progress and proportion of today\'s yes answers while reviewing</string>
 <string name="fade_scrollbars">Fade scrollbars</string>
@@ -191,12 +189,7 @@
 <string name="studyoptions_tag">By Tag</string>
 <string name="studyoptions_tag_new">Show new cards by tag:</string>
 <string name="studyoptions_tag_rev">Show review cards by tag:</string>
-<string name="studyoptions_session_minutes">Session limit (minutes):</string>
-<string name="studyoptions_session_questions">Session limit (questions):</string>
-<string name="session_time_limit">Session Time Limit</string>
-<string name="session_time_limit_summ">The number of minutes in a session. Choose 0 for no limit.</string>
-<string name="session_question_limit">Session Question Limit</string>
-<string name="session_question_limit_summ">The number of questions in a session. Choose 0 for no limit.</string>
+
 <string name="new_cards_order">New Cards Order</string>
 <string name="new_cards_order_summ">The order in which to show new cards.</string>
 <string name="show_new_cards_in">Show new cards in...</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -204,12 +204,7 @@
 	            android:key="writeAnswers"
 	            android:summary="@string/write_answers_summ"
 	            android:title="@string/write_answers" />
-<!--           	<CheckBoxPreference
-                android:defaultValue="true"
-                android:key="overtime"
-                android:summary="@string/overtime_summ"
-                android:title="@string/overtime" />
- -->            <CheckBoxPreference
+            <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="fixOrientation"
                 android:summary="@string/fix_orientation_summ"

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2653,7 +2653,6 @@ public class DeckPicker extends FragmentActivity {
         } else if (requestCode == REQUEST_REVIEW) {
             Log.i(AnkiDroidApp.TAG, "Result code = " + resultCode);
             switch (resultCode) {
-                case Reviewer.RESULT_SESSION_COMPLETED:
                 default:
                     // do not reload counts, if activity is created anew because it has been before destroyed by android
                 	loadCounts();

--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -1173,7 +1173,6 @@ public class StudyOptionsFragment extends Fragment {
                 // TODO: Return to standard scheduler
                 // TODO: handle big widget
                 switch (resultCode) {
-                    case Reviewer.RESULT_SESSION_COMPLETED:
                     default:
                         // do not reload counts, if activity is created anew because it has been before destroyed by android
                         resetAndUpdateValuesFromDeck();

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -71,9 +71,6 @@ public class Collection {
 
     private double mStartTime;
     private int mStartReps;
-    private boolean mOvertime;
-
-    private int mRepsToday;
 
     // BEGIN: SQL table columns
     private long mCrt;
@@ -142,7 +139,6 @@ public class Collection {
         }
         mStartReps = 0;
         mStartTime = 0;
-        mOvertime = false;
         mSched = new Sched(this);
         // check for improper shutdown
         cleanup();
@@ -1116,19 +1112,9 @@ public class Collection {
     }
 
 
-    public void setOvertime(boolean overtime) {
-        mOvertime = overtime;
-    }
-
-
-    public boolean getOvertime() {
-        return mOvertime;
-    }
-
-
     public void startTimebox() {
         mStartTime = Utils.now();
-        mStartReps = mRepsToday;
+        mStartReps = mSched.getReps();
     }
 
 
@@ -1140,8 +1126,8 @@ public class Collection {
                 return null;
             }
             double elapsed = Utils.now() - mStartTime;
-            if (elapsed > mConf.getLong("timeLim") && !mOvertime) {
-                return new Long[] { mConf.getLong("timeLim"), (long) (mRepsToday - mStartReps) };
+            if (elapsed > mConf.getLong("timeLim")) {
+                return new Long[] { mConf.getLong("timeLim"), (long) (mSched.getReps() - mStartReps) };
             }
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1193,7 +1179,7 @@ public class Collection {
             int n = c.getQueue() == 3 ? 1 : c.getQueue();
             String type = (new String[] { "new", "lrn", "rev" })[n];
             mSched._updateStats(c, type, -1);
-            mSched.mReps -= 1;
+            mSched.setReps(mSched.getReps() - 1);
             return c.getId();
 
     	case UNDO_EDIT_NOTE:

--- a/src/com/ichi2/libanki/Sched.java
+++ b/src/com/ichi2/libanki/Sched.java
@@ -104,7 +104,7 @@ public class Sched {
     private String mName = "std";
     private int mQueueLimit;
     private int mReportLimit;
-    public int mReps;
+    private int mReps;
     private boolean mHaveQueues;
     private int mToday;
     public long mDayCutoff;
@@ -2779,6 +2779,14 @@ public class Sched {
         return mNewCount;
     }
 
+    public int getReps(){
+    	return mReps;
+    }
+    
+    public void setReps(int reps){
+    	mReps = reps;
+    }
+    
 
     // Needed for tests
     public LinkedList<long[]> getNewQueue() {


### PR DESCRIPTION
These changes update the timeboxing behaviour so it works like on the desktop client and fixes [Issue 1355](http://code.google.com/p/ankidroid/issues/detail?id=1355).

Since sessions were removed in Anki 2 and timeboxing was closely related to that feature in the old version, I've taken the opportunity to remove anything related to sessions as well. I've left some of the `studyoptions_*` strings since I think they might be of use as filtering selections later on.

One thing to note about this commit: 
The rep count is incremented whenever the next card is fetched, which can be seen in DeckTask.doInBackgroundAnswerCard(). That's good so far. However, AnkiDroid appears to answer a "dummy" card when it first starts a review session (see the end of Reviewer.onCreate()). This prematurely increments the rep count, resulting in the first timebox being 1 more than it actually is and having one less rep for the final rep.

In both cases, I've manually accounted for the extra and missing reps at the start and end. It doesn't feel like the best solution, but it's the simplest I could come up with.
