### PR TITLE
issue 1501 and various improvements on unzipping code, importing

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="lib" path="libs/android-support-v4.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="lib" path="libs/google-gson-stream-2.2.1.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -116,4 +116,9 @@
     <string name="upgrade_deck_sync_from_ankiweb">Sync from AnkiWeb</string>
     <string name="upgrade_deck_have_you_synced">Are you sure you have upgraded your collection with Anki Desktop 2 and synced with AnkiWeb?</string>
     <string name="upgrade_deck_dont_upgrade">Don\'t Upgrade</string>
+    <string name="import_unpacking">Unpacking archive.\nPlease wait…</string>
+    <string name="importing_collection">Importing collection.\nPlease wait…</string>
+    <string name="import_media_count">Importing media files %1$d%%\nPlease wait…</string>
+    <string name="import_update_counts">Updating deck counts.\nPlease wait…</string>
+    <string name="import_add_progress">• Unpacking archive %1$s\n• Import of notes %2$d%%\n• Import of cards %3$d%%\n• Cleanup %4$s</string>
 </resources>

--- a/src/com/ichi2/anki/AnkiDb.java
+++ b/src/com/ichi2/anki/AnkiDb.java
@@ -303,4 +303,5 @@ public class AnkiDb {
             mDatabase.endTransaction();
         }
     }
+
 }

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -801,6 +801,7 @@ public class DeckPicker extends FragmentActivity {
         }
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
+            mProgressDialog.setMessage(values[0].getString());
         }
     };
 
@@ -836,6 +837,7 @@ public class DeckPicker extends FragmentActivity {
         }
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
+            mProgressDialog.setMessage(values[0].getString());
         }
     };
 

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -957,6 +957,7 @@ public class Info extends Activity {
         }
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
+            mProgressDialog.setMessage(values[0].getString());
         }
     };
 


### PR DESCRIPTION
progress messages, fixes on import media bugs

A general close inspection of the import code. There were multiple bugs on the media import (written earlier by me for 2.0.1, but never really tested, he, he), should be working better now, importing files when needed, skipping if the file already exists in collection.media folder and looks the same (only the first 1024 bytes are compared for speed reasons and of course only when filenames match).

Much better feedback to the user, as this operation can take a while.
