### PR TITLE
Prevent dialog dismissal when clicking outside dialog on Android > 4.0

### DIFF
--- a/src/com/ichi2/themes/StyledDialog.java
+++ b/src/com/ichi2/themes/StyledDialog.java
@@ -61,6 +61,7 @@ public class StyledDialog extends Dialog {
     @Override
     public void show() {
         try {
+            setCanceledOnTouchOutside(false);
             super.show();
         } catch (BadTokenException e) {
             Log.e(AnkiDroidApp.TAG, "Could not show dialog: " + e);

--- a/src/com/ichi2/themes/StyledOpenCollectionDialog.java
+++ b/src/com/ichi2/themes/StyledOpenCollectionDialog.java
@@ -45,6 +45,7 @@ public class StyledOpenCollectionDialog extends Dialog {
     @Override
     public void show() {
         try {
+            setCanceledOnTouchOutside(false);
             super.show();
         } catch (BadTokenException e) {
             Log.e(AnkiDroidApp.TAG, "Could not show dialog: " + e);

--- a/src/com/ichi2/themes/StyledProgressDialog.java
+++ b/src/com/ichi2/themes/StyledProgressDialog.java
@@ -46,6 +46,7 @@ public class StyledProgressDialog extends Dialog {
     @Override
     public void show() {
         try {
+            setCanceledOnTouchOutside(false);
             super.show();
         } catch (BadTokenException e) {
             Log.e(AnkiDroidApp.TAG, "Could not show dialog: " + e);


### PR DESCRIPTION
Doesn't really fix 1563, just one symptom of it.

I think the real problem is that we use Dialog and not DialogFragment.
