### PR TITLE
Issue 1640 - Move sync account from menu to preferences

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -146,6 +146,9 @@
 <string name="shake_intensity_summ">Threshold for shake recognition: XXX</string>
 <string name="sync_fetch_missing_media">Fetch media on sync</string>
 <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing.</string>
+<string name="sync_account">AnkiWeb account</string>
+<string name="sync_account_summ_logged_out">AnkiWeb account details required</string>
+<string name="sync_account_summ_logged_in">Using AnkiWeb ID: %s</string>
 <string name="fix_hebrew_text">Fix for Hebrew vowels</string>
 <string name="fix_hebrew_text_summ">Workaround for rendering Hebrew vowels correctly.</string>
 <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to:\n%s/fonts/\n\nYou won\'t have to modify your cards.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -123,6 +123,15 @@
                 android:title="@string/pref_show_splashscreen" />
 	</PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_sync" >
+          <Preference
+                android:key="syncAccount"
+                android:dialogTitle="@string/sync_account"
+                android:summary="@string/sync_account_summ_logged_out"
+                android:title="@string/sync_account">
+                <intent
+                    android:targetPackage="com.ichi2.anki"
+                    android:targetClass="com.ichi2.anki.MyAccount"/>
+          </Preference>
           <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="syncFetchesMedia"

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -142,7 +142,6 @@ public class DeckPicker extends FragmentActivity {
     private static final int MENU_CREATE_DECK = 1;
     private static final int MENU_ADD_SHARED_DECK = 2;
     private static final int MENU_PREFERENCES = 3;
-    private static final int MENU_MY_ACCOUNT = 4;
     private static final int MENU_FEEDBACK = 5;
     private static final int MENU_HELP = 6;
     private static final int CHECK_DATABASE = 7;
@@ -2352,8 +2351,6 @@ public class DeckPicker extends FragmentActivity {
 
         item = menu.add(Menu.NONE, MENU_PREFERENCES, Menu.NONE, R.string.menu_preferences);
         item.setIcon(R.drawable.ic_menu_preferences);
-        item = menu.add(Menu.NONE, MENU_MY_ACCOUNT, Menu.NONE, R.string.menu_my_account);
-        item.setIcon(R.drawable.ic_menu_home);
         item = menu.add(Menu.NONE, MENU_ADD_SHARED_DECK, Menu.NONE, R.string.menu_get_shared_decks);
         item.setIcon(R.drawable.ic_menu_download);
         item = menu.add(Menu.NONE, MENU_CREATE_DECK, Menu.NONE, R.string.new_deck);
@@ -2503,10 +2500,6 @@ public class DeckPicker extends FragmentActivity {
             case MENU_IMPORT:
             	showDialog(DIALOG_IMPORT_HINT);
            	return true;
-
-            case MENU_MY_ACCOUNT:
-                startActivity(new Intent(DeckPicker.this, MyAccount.class));
-                return true;
 
             case MENU_PREFERENCES:
                 startActivityForResult(new Intent(DeckPicker.this, Preferences.class), PREFERENCES_UPDATE);

--- a/src/com/ichi2/anki/Preferences.java
+++ b/src/com/ichi2/anki/Preferences.java
@@ -31,6 +31,7 @@ import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -78,6 +79,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
     private CheckBoxPreference fadeScrollbars;
     private CheckBoxPreference convertFenText;
     private CheckBoxPreference fixHebrewText;
+    private Preference syncAccount;
     private ListPreference mLanguageSelection;
     private CharSequence[] mLanguageDialogLabels;
     private CharSequence[] mLanguageDialogValues;
@@ -124,6 +126,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
 //        ListPreference listpref = (ListPreference) getPreferenceScreen().findPreference("theme");
         convertFenText = (CheckBoxPreference) getPreferenceScreen().findPreference("convertFenText");
         fixHebrewText = (CheckBoxPreference) getPreferenceScreen().findPreference("fixHebrewText");
+        syncAccount = (Preference) getPreferenceScreen().findPreference("syncAccount");
 //        String theme = listpref.getValue();
 //        animationsCheckboxPreference.setEnabled(theme.equals("2") || theme.equals("3"));
         zoomCheckboxPreference.setEnabled(!swipeCheckboxPreference.isChecked());
@@ -263,6 +266,20 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
         super.onPause();
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // syncAccount's summary can change while preferences are still open (user logs
+        // in from preferences screen), so we need to update it here.
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        if (preferences.getString("hkey", "").length() > 0) {
+            String username = preferences.getString("username", "");
+            Resources res = getResources();
+            syncAccount.setSummary(String.format(res.getString(R.string.sync_account_summ_logged_in), username));
+        } else {
+            syncAccount.setSummary(R.string.sync_account_summ_logged_out);
+        }
+    }
 
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         try {


### PR DESCRIPTION
As per [Issue 1640](http://code.google.com/p/ankidroid/issues/detail?id=1640), this removes the menu option "Sync account" and instead places it in Preferences -> General -> Synchronization. 

I don't know if launching an activity from the preferences screen is a bad idea. I'm still new to this Android stuff, so any feedback is appreciated.
