### PR TITLE
Improve TTS initialization and queuing.

### DIFF
--- a/src/com/ichi2/anki/ReadText.java
+++ b/src/com/ichi2/anki/ReadText.java
@@ -28,6 +28,7 @@ import com.ichi2.libanki.Sched;
 import com.ichi2.themes.StyledDialog;
 
 import android.speech.tts.TextToSpeech;
+import android.speech.tts.TextToSpeech.OnInitListener;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
 import android.speech.tts.UtteranceProgressListener;
 import android.content.Context;
@@ -47,18 +48,14 @@ public class ReadText {
     public static ArrayList<String[]> sTextQueue = new ArrayList<String[]>();
     public static HashMap<String, String> mTtsParams;
 
-    // private boolean mTtsReady = false;
+    static public boolean mTTSInitDone = false;
 
     public static void speak(String text, String loc) {
         int result = mTts.setLanguage(new Locale(loc));
         if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
             Log.e(AnkiDroidApp.TAG, "Error loading locale " + loc.toString());
         } else {
-        	if (mTts.isSpeaking()) {
-        		sTextQueue.add(new String[]{text, loc});
-        	} else {
-                mTts.speak(mTextToSpeak, TextToSpeech.QUEUE_FLUSH, mTtsParams);        		
-        	}
+            mTts.speak(mTextToSpeak, TextToSpeech.QUEUE_FLUSH, mTtsParams);        		
         }
     }
 
@@ -75,20 +72,12 @@ public class ReadText {
         mOrd = ord;
 
         String language = getLanguage(mDid, mOrd, mQuestionAnswer);
-        if (availableTtsLocales.isEmpty()) {
-            Locale[] systemLocales = Locale.getAvailableLocales();
-            for (Locale loc : systemLocales) {
-                if (mTts.isLanguageAvailable(loc) == TextToSpeech.LANG_COUNTRY_AVAILABLE) {
-                    availableTtsLocales.add(new String[] { loc.getISO3Language(), loc.getDisplayName() });
-                }
-            }
-        }
-
-        // Check, if stored language is available
-        for (int i = 0; i < availableTtsLocales.size(); i++) {
+        Locale loc = new Locale(language);
             if (language.equals(NO_TTS)) {
                 return;
-            } else if (language.equals(availableTtsLocales.get(i)[0])) {
+        }
+        if (mTts != null) {
+            if (mTts.isLanguageAvailable(loc) != TextToSpeech.LANG_NOT_SUPPORTED) {
                 speak(mTextToSpeak, language);
                 return;
             }
@@ -131,24 +120,10 @@ public class ReadText {
 
     public static void initializeTts(Context context) {
         mReviewer = context;
-        mTts = new TextToSpeech(context, new TextToSpeech.OnInitListener() {
-            @Override
-            public void onInit(int status) {
-                // TODO: check if properly initialized (does not work yet)
-                if (status != TextToSpeech.SUCCESS) {
-                    int result = mTts.setLanguage(Locale.US);
-                    if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-                    } else {
-                        Log.e(AnkiDroidApp.TAG, "TTS initialized and set to US");
-                    }
-                } else {
-                    Log.e(AnkiDroidApp.TAG, "Initialization of TTS failed");
-                }
-                AnkiDroidApp.getCompat().setTtsOnUtteranceProgressListener(mTts);
-            }
-        });
-        mTtsParams = new HashMap<String, String>();
-        mTtsParams.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID,"stringId");
+        mTTSInitDone = false;
+        Log.i(AnkiDroidApp.TAG, "initializeTts");
+        final TTSInitListener listener = new TTSInitListener();
+        mTts = new TextToSpeech(context, listener);
     }
 
 
@@ -166,6 +141,14 @@ public class ReadText {
         		sTextQueue.clear();
         	}
             mTts.stop();
+        }
+    }
+
+    private static class TTSInitListener implements OnInitListener {
+
+        public void onInit(int status) {
+            Log.i(AnkiDroidApp.TAG, "TTS onInit");
+            mTTSInitDone = true;
         }
     }
 }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -18,6 +18,7 @@
 package com.ichi2.anki;
 
 import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -36,6 +37,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.media.AudioManager;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -424,7 +426,7 @@ public class Reviewer extends AnkiActivity {
     private Method mSetTextIsSelectable = null;
 
     private Sched mSched;
-
+    private static ProgressDialog mTTSProgressDialog;
     // private int zEase;
 
     // ----------------------------------------------------------------------------
@@ -984,6 +986,39 @@ public class Reviewer extends AnkiActivity {
             // Initialize text-to-speech. This is an asynchronous operation.
             if (mSpeakText) {
                 ReadText.initializeTts(this);
+                mTTSProgressDialog = new ProgressDialog(this);
+
+                new AsyncTask<String, Void, Void>() {
+
+                    @Override
+                    protected void onPreExecute() {
+                        mTTSProgressDialog.setMessage("Init TTS");
+                        mTTSProgressDialog.show();
+                    }
+                    @Override
+                    protected Void doInBackground(String... params) {
+                        while (ReadText.mTTSInitDone == false) {
+                            try {
+                                Thread.sleep(500);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                        return null;
+                    }
+
+                    @Override
+                    protected void onPostExecute(Void res) {
+                        mTTSProgressDialog.dismiss();
+
+                        // Load the first card and start reviewing. Uses the answer card
+                        // task to load a card, but since we send null
+                        // as the card to answer, no card will be answered.
+                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(mSched,
+                            null, 0));
+                    }
+                }.execute();
+
             }
 
             // Get last whiteboard state


### PR DESCRIPTION
This is the patch to improve TTS loading and reading that was [submitted on the forums](https://groups.google.com/forum/#!msg/anki-android/vggjjptptG4/fn8LaDORbjYJ). I cleaned it up a bit from the original source.

Changes:
- Don't loop over all TTS locales to find if current card's language is available.
- Cut question reading when card is flipped. Start answer immediately.
- Waiting dialog while TTS initializes.
